### PR TITLE
Datas de criação das instancias incluídas e instâncias ordenadas pela mesma

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -153,11 +153,11 @@ for domain_name in data:
 			print(time_use)
 			if get_create_date(instance) == maximum_date:
 				continue
-			
+
 			if instance["Name"].strip() == "":
 				instance["Name"] = empty_value
 
-			instances += ("\t\t<tr> <td>%s</td> <td>%s</td> <td>%s</td> <td>%s</td> </tr>\n" % (instance["Name"], instance["Flavor"], time_use, get_create_date(instance)))
+			instances += ("\t\t<tr> <td>%s</td> <td>%s</td> <td>%s</td> <td>%s</td> </tr>\n" % (instance["Name"], instance["Flavor"], time_use, get_create_date(instance).date()))
 
 		body = body.replace("$inst$", instances)
 

--- a/reports/04-2020/UASC.html
+++ b/reports/04-2020/UASC.html
@@ -31,13 +31,13 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>web-pos</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-27 17:51:34</td> </tr>
-		<tr> <td>dsc-alumni</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-27 17:52:29</td> </tr>
-		<tr> <td>reservas-hattori</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-27 17:53:38</td> </tr>
-		<tr> <td>inscrição-copin</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-27 18:05:30</td> </tr>
-		<tr> <td>disciplinabd</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-09-16 19:24:17</td> </tr>
-		<tr> <td>disciplina-fabio</td> <td>lsd.t1.medium_fabio</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-12-17 17:38:51</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>web-pos</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-27</td> </tr>
+		<tr> <td>dsc-alumni</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-27</td> </tr>
+		<tr> <td>reservas-hattori</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-27</td> </tr>
+		<tr> <td>inscrição-copin</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-27</td> </tr>
+		<tr> <td>disciplinabd</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-09-16</td> </tr>
+		<tr> <td>disciplina-fabio</td> <td>lsd.t1.medium_fabio</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-12-17</td> </tr>
 
     </table>
     

--- a/reports/04-2020/adalberto@computacao.ufcg.edu.br.html
+++ b/reports/04-2020/adalberto@computacao.ufcg.edu.br.html
@@ -31,8 +31,8 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>Servidor1</td> <td>lsd.t2.large</td> <td>29 Dias, 7 Horas e 29 Segundos</td> <td>2020-04-01 16:54:31</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>Servidor1</td> <td>lsd.t2.large</td> <td>29 Dias, 7 Horas e 29 Segundos</td> <td>2020-04-01</td> </tr>
 
     </table>
     
@@ -62,10 +62,10 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>servidor-artefatos</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-07-31 11:39:39</td> </tr>
-		<tr> <td>servidor-leda</td> <td>lsd.t2.xlarge</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-07-31 15:50:24</td> </tr>
-		<tr> <td>servidor-auxiliar</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-07-31 19:31:25</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>servidor-artefatos</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-07-31</td> </tr>
+		<tr> <td>servidor-leda</td> <td>lsd.t2.xlarge</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-07-31</td> </tr>
+		<tr> <td>servidor-auxiliar</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-07-31</td> </tr>
 
     </table>
     

--- a/reports/04-2020/andrey@computacao.ufcg.edu.br.html
+++ b/reports/04-2020/andrey@computacao.ufcg.edu.br.html
@@ -33,29 +33,29 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>Nialm</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-12 18:21:34</td> </tr>
-		<tr> <td>master-small-cluster</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10 15:21:31</td> </tr>
-		<tr> <td>worker0-small-cluster</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10 15:35:13</td> </tr>
-		<tr> <td>worker1-small-cluster</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10 15:36:08</td> </tr>
-		<tr> <td>worker2-small-cluster</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10 15:41:10</td> </tr>
-		<tr> <td>worker3-small-cluster</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10 15:43:22</td> </tr>
-		<tr> <td>worker0-big-cluster</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10 16:57:16</td> </tr>
-		<tr> <td>worker1-big-cluster</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10 17:00:55</td> </tr>
-		<tr> <td>worker2-big-cluster</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10 17:02:37</td> </tr>
-		<tr> <td>worker3-big-cluster</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10 17:05:39</td> </tr>
-		<tr> <td>master-big-cluster</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10 19:19:27</td> </tr>
-		<tr> <td>Jenkins</td> <td>lsd.t2.xlarge</td> <td>20 Dias, 10 Horas e 18 Segundos</td> <td>2020-04-10 13:22:42</td> </tr>
-		<tr> <td>jenkinsteste</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 27 Segundos</td> <td>2020-04-24 19:39:10</td> </tr>
-		<tr> <td>jenkinsteste</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 10 Segundos</td> <td>2020-04-24 19:40:10</td> </tr>
-		<tr> <td>ci-asperathos-master</td> <td>lsd.t1.medium</td> <td>0 Dias, 0 Horas e 19 Segundos</td> <td>2020-04-29 17:19:30</td> </tr>
-		<tr> <td>ci-asperathos-minion-3</td> <td>lsd.t1.medium</td> <td>1 Dias, 6 Horas e 9 Segundos</td> <td>2020-04-29 17:21:51</td> </tr>
-		<tr> <td>ci-asperathos-minion-2</td> <td>lsd.t1.medium</td> <td>1 Dias, 6 Horas e 9 Segundos</td> <td>2020-04-29 17:21:51</td> </tr>
-		<tr> <td>ci-asperathos-minion-1</td> <td>lsd.t1.medium</td> <td>1 Dias, 6 Horas e 5 Segundos</td> <td>2020-04-29 17:21:55</td> </tr>
-		<tr> <td>ci-asperathos-master</td> <td>lsd.t1.medium</td> <td>1 Dias, 6 Horas e 43 Segundos</td> <td>2020-04-29 17:25:17</td> </tr>
-		<tr> <td>docker-registry-teste</td> <td>lsd.t1.small</td> <td>0 Dias, 21 Horas e 28 Segundos</td> <td>2020-04-29 19:38:19</td> </tr>
-		<tr> <td>docker-registry-backup</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 20 Segundos</td> <td>2020-04-30 17:10:03</td> </tr>
-		<tr> <td>docker-registry</td> <td>lsd.t2.large</td> <td>0 Dias, 6 Horas e 4 Segundos</td> <td>2020-04-30 17:15:56</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>Nialm</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-12</td> </tr>
+		<tr> <td>master-small-cluster</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10</td> </tr>
+		<tr> <td>worker0-small-cluster</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10</td> </tr>
+		<tr> <td>worker1-small-cluster</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10</td> </tr>
+		<tr> <td>worker2-small-cluster</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10</td> </tr>
+		<tr> <td>worker3-small-cluster</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10</td> </tr>
+		<tr> <td>worker0-big-cluster</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10</td> </tr>
+		<tr> <td>worker1-big-cluster</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10</td> </tr>
+		<tr> <td>worker2-big-cluster</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10</td> </tr>
+		<tr> <td>worker3-big-cluster</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10</td> </tr>
+		<tr> <td>master-big-cluster</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10</td> </tr>
+		<tr> <td>Jenkins</td> <td>lsd.t2.xlarge</td> <td>20 Dias, 10 Horas e 18 Segundos</td> <td>2020-04-10</td> </tr>
+		<tr> <td>jenkinsteste</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 27 Segundos</td> <td>2020-04-24</td> </tr>
+		<tr> <td>jenkinsteste</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 10 Segundos</td> <td>2020-04-24</td> </tr>
+		<tr> <td>ci-asperathos-master</td> <td>lsd.t1.medium</td> <td>0 Dias, 0 Horas e 19 Segundos</td> <td>2020-04-29</td> </tr>
+		<tr> <td>ci-asperathos-minion-3</td> <td>lsd.t1.medium</td> <td>1 Dias, 6 Horas e 9 Segundos</td> <td>2020-04-29</td> </tr>
+		<tr> <td>ci-asperathos-minion-2</td> <td>lsd.t1.medium</td> <td>1 Dias, 6 Horas e 9 Segundos</td> <td>2020-04-29</td> </tr>
+		<tr> <td>ci-asperathos-minion-1</td> <td>lsd.t1.medium</td> <td>1 Dias, 6 Horas e 5 Segundos</td> <td>2020-04-29</td> </tr>
+		<tr> <td>ci-asperathos-master</td> <td>lsd.t1.medium</td> <td>1 Dias, 6 Horas e 43 Segundos</td> <td>2020-04-29</td> </tr>
+		<tr> <td>docker-registry-teste</td> <td>lsd.t1.small</td> <td>0 Dias, 21 Horas e 28 Segundos</td> <td>2020-04-29</td> </tr>
+		<tr> <td>docker-registry-backup</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 20 Segundos</td> <td>2020-04-30</td> </tr>
+		<tr> <td>docker-registry</td> <td>lsd.t2.large</td> <td>0 Dias, 6 Horas e 4 Segundos</td> <td>2020-04-30</td> </tr>
 
     </table>
     
@@ -86,9 +86,9 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>ipfs</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-22 14:18:51</td> </tr>
-		<tr> <td>ipfs-large</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-12-06 23:21:19</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>ipfs</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-22</td> </tr>
+		<tr> <td>ipfs-large</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-12-06</td> </tr>
 
     </table>
     
@@ -119,63 +119,63 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>scontain-sshd</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-06 11:45:03</td> </tr>
-		<tr> <td>proxysql-4</td> <td>lsd.t1.medium</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-20 15:04:06</td> </tr>
-		<tr> <td>mdb-haproxy-1</td> <td>lsd.t1.medium</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30 01:06:44</td> </tr>
-		<tr> <td>mdb-haproxy-3</td> <td>lsd.t1.medium</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30 01:06:46</td> </tr>
-		<tr> <td>mdb-haproxy-2</td> <td>lsd.t1.medium</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30 01:06:46</td> </tr>
-		<tr> <td>lucas-scaling-1</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30 11:54:43</td> </tr>
-		<tr> <td>lucas-scaling-2</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30 11:54:48</td> </tr>
-		<tr> <td>lucas-scaling-3</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30 11:54:48</td> </tr>
-		<tr> <td>clenimar-mdb-node-4</td> <td>sgx-scalable.epc30.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30 14:07:23</td> </tr>
-		<tr> <td>clenimar-mdb-node-1</td> <td>sgx-scalable.epc30.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30 14:07:26</td> </tr>
-		<tr> <td>clenimar-mdb-node-2</td> <td>sgx-scalable.epc30.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30 14:07:28</td> </tr>
-		<tr> <td>clenimar-mdb-node-6</td> <td>sgx-scalable.epc30.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30 14:07:30</td> </tr>
-		<tr> <td>clenimar-mdb-node-3</td> <td>sgx-scalable.epc30.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30 14:07:30</td> </tr>
-		<tr> <td>clenimar-mdb-node-5</td> <td>sgx-scalable.epc30.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30 14:09:30</td> </tr>
-		<tr> <td>clenimar-maxscale</td> <td>sgx-scalable.epc30.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30 14:10:46</td> </tr>
-		<tr> <td>clenimar-client-1</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30 15:11:24</td> </tr>
-		<tr> <td>clenimar-client-2</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-31 17:50:34</td> </tr>
-		<tr> <td>benchmark-3</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-31 18:43:56</td> </tr>
-		<tr> <td>benchmark-1</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-31 18:44:00</td> </tr>
-		<tr> <td>benchmark-2</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-31 18:44:02</td> </tr>
-		<tr> <td>haproxy</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-31 19:19:30</td> </tr>
-		<tr> <td>clenimar-maxscale-2</td> <td>sgx.epc16.medium</td> <td>4 Dias, 21 Horas e 18 Segundos</td> <td>2020-04-02 03:27:40</td> </tr>
-		<tr> <td>couchdb1</td> <td>lsd.t2.large</td> <td>3 Dias, 20 Horas e 5 Segundos</td> <td>2020-04-06 01:05:21</td> </tr>
-		<tr> <td>couchdb2</td> <td>lsd.t1.medium</td> <td>0 Dias, 16 Horas e 13 Segundos</td> <td>2020-04-06 01:07:36</td> </tr>
-		<tr> <td>mdb-arch-1</td> <td>sgx.epc16.medium</td> <td>3 Dias, 12 Horas e 15 Segundos</td> <td>2020-04-07 00:42:00</td> </tr>
-		<tr> <td>mdb-arch-3</td> <td>sgx.epc16.medium</td> <td>3 Dias, 12 Horas e 14 Segundos</td> <td>2020-04-07 00:42:05</td> </tr>
-		<tr> <td>mdb-arch-2</td> <td>sgx.epc16.medium</td> <td>3 Dias, 12 Horas e 7 Segundos</td> <td>2020-04-07 00:42:07</td> </tr>
-		<tr> <td>mdb-bench-check</td> <td>sgx-scalable.epc30.large</td> <td>3 Dias, 1 Horas e 57 Segundos</td> <td>2020-04-07 12:28:47</td> </tr>
-		<tr> <td>kafka-mariadb</td> <td>lsd.t1.medium</td> <td>8 Dias, 23 Horas e 33 Segundos</td> <td>2020-04-08 18:19:36</td> </tr>
-		<tr> <td>kafka-mariadb2</td> <td>lsd.t1.medium</td> <td>7 Dias, 20 Horas e 32 Segundos</td> <td>2020-04-09 21:54:51</td> </tr>
-		<tr> <td>kafka-mariadb3</td> <td>lsd.t1.medium</td> <td>7 Dias, 20 Horas e 26 Segundos</td> <td>2020-04-09 22:04:01</td> </tr>
-		<tr> <td>maria-db4</td> <td>lsd.t2.large</td> <td>7 Dias, 13 Horas e 53 Segundos</td> <td>2020-04-10 04:28:52</td> </tr>
-		<tr> <td>mariadb-5</td> <td>lsd.t1.tiny</td> <td>7 Dias, 13 Horas e 54 Segundos</td> <td>2020-04-10 04:49:15</td> </tr>
-		<tr> <td>mdb-shard-3</td> <td>sgx-scalable.epc30.large</td> <td>10 Dias, 11 Horas e 55 Segundos</td> <td>2020-04-10 13:37:09</td> </tr>
-		<tr> <td>mdb-shard-2</td> <td>sgx-scalable.epc30.large</td> <td>10 Dias, 11 Horas e 52 Segundos</td> <td>2020-04-10 13:37:11</td> </tr>
-		<tr> <td>mdb-shard-1</td> <td>sgx-scalable.epc30.large</td> <td>10 Dias, 11 Horas e 51 Segundos</td> <td>2020-04-10 13:37:12</td> </tr>
-		<tr> <td>mdb-shard-4</td> <td>sgx-scalable.epc30.large</td> <td>20 Dias, 10 Horas e 31 Segundos</td> <td>2020-04-10 13:37:29</td> </tr>
-		<tr> <td>mdb-shard-4</td> <td>sgx-scalable.epc30.large</td> <td>0 Dias, 0 Horas e 12 Segundos</td> <td>2020-04-10 13:43:15</td> </tr>
-		<tr> <td>mdb-max</td> <td>sgx-scalable.epc30.large</td> <td>10 Dias, 11 Horas e 27 Segundos</td> <td>2020-04-10 14:09:36</td> </tr>
-		<tr> <td>mdb-shard-4</td> <td>sgx-scalable.epc30.large</td> <td>10 Dias, 11 Horas e 3 Segundos</td> <td>2020-04-10 14:31:00</td> </tr>
-		<tr> <td>mdb-max2</td> <td>sgx-scalable.epc30.large</td> <td>10 Dias, 1 Horas e 52 Segundos</td> <td>2020-04-11 00:26:12</td> </tr>
-		<tr> <td>max-native</td> <td>lsd.t2.large</td> <td>9 Dias, 22 Horas e 20 Segundos</td> <td>2020-04-11 03:05:12</td> </tr>
-		<tr> <td>mdb-max3</td> <td>sgx-scalable.epc30.large</td> <td>8 Dias, 11 Horas e 21 Segundos</td> <td>2020-04-12 14:06:41</td> </tr>
-		<tr> <td>mariadb-shard-1</td> <td>sgx.epc16.medium</td> <td>3 Dias, 2 Horas e 56 Segundos</td> <td>2020-04-17 18:11:41</td> </tr>
-		<tr> <td>mariadb-shard-2</td> <td>sgx.epc16.medium</td> <td>3 Dias, 2 Horas e 36 Segundos</td> <td>2020-04-17 18:11:43</td> </tr>
-		<tr> <td>mariadb-shard-1</td> <td>sgx.epc16.medium</td> <td>0 Dias, 0 Horas e 31 Segundos</td> <td>2020-04-21 00:27:43</td> </tr>
-		<tr> <td>mariadb-shard-2</td> <td>sgx.epc16.medium</td> <td>0 Dias, 0 Horas e 57 Segundos</td> <td>2020-04-21 00:27:45</td> </tr>
-		<tr> <td>mariadb-shard-1</td> <td>sgx.epc16.medium</td> <td>1 Dias, 5 Horas e 29 Segundos</td> <td>2020-04-21 00:43:18</td> </tr>
-		<tr> <td>mariadb-shard-2</td> <td>sgx.epc16.medium</td> <td>1 Dias, 5 Horas e 3 Segundos</td> <td>2020-04-21 00:43:19</td> </tr>
-		<tr> <td>mariadb-shard-2</td> <td>sgx-scalable.epc30.large</td> <td>8 Dias, 17 Horas e 44 Segundos</td> <td>2020-04-22 06:25:16</td> </tr>
-		<tr> <td>mariadb-shard-1</td> <td>sgx-scalable.epc30.large</td> <td>8 Dias, 17 Horas e 42 Segundos</td> <td>2020-04-22 06:25:18</td> </tr>
-		<tr> <td>max-scale</td> <td>sgx-scalable.epc30.large</td> <td>8 Dias, 16 Horas e 43 Segundos</td> <td>2020-04-22 07:37:17</td> </tr>
-		<tr> <td>cas</td> <td>sgx.epc16.medium</td> <td>3 Dias, 9 Horas e 22 Segundos</td> <td>2020-04-27 14:31:38</td> </tr>
-		<tr> <td>K8s-misc-tests</td> <td>sgx-scalable.epc30.large</td> <td>2 Dias, 6 Horas e 4 Segundos</td> <td>2020-04-28 17:05:56</td> </tr>
-		<tr> <td>kafka</td> <td>lsd.t1.medium</td> <td>2 Dias, 2 Horas e 45 Segundos</td> <td>2020-04-28 21:39:15</td> </tr>
-		<tr> <td>icelake-benchmark-prep</td> <td>sgx-scalable.epc30.large</td> <td>1 Dias, 3 Horas e 53 Segundos</td> <td>2020-04-29 20:48:07</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>scontain-sshd</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-06</td> </tr>
+		<tr> <td>proxysql-4</td> <td>lsd.t1.medium</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-20</td> </tr>
+		<tr> <td>mdb-haproxy-1</td> <td>lsd.t1.medium</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30</td> </tr>
+		<tr> <td>mdb-haproxy-3</td> <td>lsd.t1.medium</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30</td> </tr>
+		<tr> <td>mdb-haproxy-2</td> <td>lsd.t1.medium</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30</td> </tr>
+		<tr> <td>lucas-scaling-1</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30</td> </tr>
+		<tr> <td>lucas-scaling-2</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30</td> </tr>
+		<tr> <td>lucas-scaling-3</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30</td> </tr>
+		<tr> <td>clenimar-mdb-node-4</td> <td>sgx-scalable.epc30.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30</td> </tr>
+		<tr> <td>clenimar-mdb-node-1</td> <td>sgx-scalable.epc30.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30</td> </tr>
+		<tr> <td>clenimar-mdb-node-2</td> <td>sgx-scalable.epc30.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30</td> </tr>
+		<tr> <td>clenimar-mdb-node-6</td> <td>sgx-scalable.epc30.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30</td> </tr>
+		<tr> <td>clenimar-mdb-node-3</td> <td>sgx-scalable.epc30.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30</td> </tr>
+		<tr> <td>clenimar-mdb-node-5</td> <td>sgx-scalable.epc30.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30</td> </tr>
+		<tr> <td>clenimar-maxscale</td> <td>sgx-scalable.epc30.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30</td> </tr>
+		<tr> <td>clenimar-client-1</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-30</td> </tr>
+		<tr> <td>clenimar-client-2</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-31</td> </tr>
+		<tr> <td>benchmark-3</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-31</td> </tr>
+		<tr> <td>benchmark-1</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-31</td> </tr>
+		<tr> <td>benchmark-2</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-31</td> </tr>
+		<tr> <td>haproxy</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-31</td> </tr>
+		<tr> <td>clenimar-maxscale-2</td> <td>sgx.epc16.medium</td> <td>4 Dias, 21 Horas e 18 Segundos</td> <td>2020-04-02</td> </tr>
+		<tr> <td>couchdb1</td> <td>lsd.t2.large</td> <td>3 Dias, 20 Horas e 5 Segundos</td> <td>2020-04-06</td> </tr>
+		<tr> <td>couchdb2</td> <td>lsd.t1.medium</td> <td>0 Dias, 16 Horas e 13 Segundos</td> <td>2020-04-06</td> </tr>
+		<tr> <td>mdb-arch-1</td> <td>sgx.epc16.medium</td> <td>3 Dias, 12 Horas e 15 Segundos</td> <td>2020-04-07</td> </tr>
+		<tr> <td>mdb-arch-3</td> <td>sgx.epc16.medium</td> <td>3 Dias, 12 Horas e 14 Segundos</td> <td>2020-04-07</td> </tr>
+		<tr> <td>mdb-arch-2</td> <td>sgx.epc16.medium</td> <td>3 Dias, 12 Horas e 7 Segundos</td> <td>2020-04-07</td> </tr>
+		<tr> <td>mdb-bench-check</td> <td>sgx-scalable.epc30.large</td> <td>3 Dias, 1 Horas e 57 Segundos</td> <td>2020-04-07</td> </tr>
+		<tr> <td>kafka-mariadb</td> <td>lsd.t1.medium</td> <td>8 Dias, 23 Horas e 33 Segundos</td> <td>2020-04-08</td> </tr>
+		<tr> <td>kafka-mariadb2</td> <td>lsd.t1.medium</td> <td>7 Dias, 20 Horas e 32 Segundos</td> <td>2020-04-09</td> </tr>
+		<tr> <td>kafka-mariadb3</td> <td>lsd.t1.medium</td> <td>7 Dias, 20 Horas e 26 Segundos</td> <td>2020-04-09</td> </tr>
+		<tr> <td>maria-db4</td> <td>lsd.t2.large</td> <td>7 Dias, 13 Horas e 53 Segundos</td> <td>2020-04-10</td> </tr>
+		<tr> <td>mariadb-5</td> <td>lsd.t1.tiny</td> <td>7 Dias, 13 Horas e 54 Segundos</td> <td>2020-04-10</td> </tr>
+		<tr> <td>mdb-shard-3</td> <td>sgx-scalable.epc30.large</td> <td>10 Dias, 11 Horas e 55 Segundos</td> <td>2020-04-10</td> </tr>
+		<tr> <td>mdb-shard-2</td> <td>sgx-scalable.epc30.large</td> <td>10 Dias, 11 Horas e 52 Segundos</td> <td>2020-04-10</td> </tr>
+		<tr> <td>mdb-shard-1</td> <td>sgx-scalable.epc30.large</td> <td>10 Dias, 11 Horas e 51 Segundos</td> <td>2020-04-10</td> </tr>
+		<tr> <td>mdb-shard-4</td> <td>sgx-scalable.epc30.large</td> <td>20 Dias, 10 Horas e 31 Segundos</td> <td>2020-04-10</td> </tr>
+		<tr> <td>mdb-shard-4</td> <td>sgx-scalable.epc30.large</td> <td>0 Dias, 0 Horas e 12 Segundos</td> <td>2020-04-10</td> </tr>
+		<tr> <td>mdb-max</td> <td>sgx-scalable.epc30.large</td> <td>10 Dias, 11 Horas e 27 Segundos</td> <td>2020-04-10</td> </tr>
+		<tr> <td>mdb-shard-4</td> <td>sgx-scalable.epc30.large</td> <td>10 Dias, 11 Horas e 3 Segundos</td> <td>2020-04-10</td> </tr>
+		<tr> <td>mdb-max2</td> <td>sgx-scalable.epc30.large</td> <td>10 Dias, 1 Horas e 52 Segundos</td> <td>2020-04-11</td> </tr>
+		<tr> <td>max-native</td> <td>lsd.t2.large</td> <td>9 Dias, 22 Horas e 20 Segundos</td> <td>2020-04-11</td> </tr>
+		<tr> <td>mdb-max3</td> <td>sgx-scalable.epc30.large</td> <td>8 Dias, 11 Horas e 21 Segundos</td> <td>2020-04-12</td> </tr>
+		<tr> <td>mariadb-shard-1</td> <td>sgx.epc16.medium</td> <td>3 Dias, 2 Horas e 56 Segundos</td> <td>2020-04-17</td> </tr>
+		<tr> <td>mariadb-shard-2</td> <td>sgx.epc16.medium</td> <td>3 Dias, 2 Horas e 36 Segundos</td> <td>2020-04-17</td> </tr>
+		<tr> <td>mariadb-shard-1</td> <td>sgx.epc16.medium</td> <td>0 Dias, 0 Horas e 31 Segundos</td> <td>2020-04-21</td> </tr>
+		<tr> <td>mariadb-shard-2</td> <td>sgx.epc16.medium</td> <td>0 Dias, 0 Horas e 57 Segundos</td> <td>2020-04-21</td> </tr>
+		<tr> <td>mariadb-shard-1</td> <td>sgx.epc16.medium</td> <td>1 Dias, 5 Horas e 29 Segundos</td> <td>2020-04-21</td> </tr>
+		<tr> <td>mariadb-shard-2</td> <td>sgx.epc16.medium</td> <td>1 Dias, 5 Horas e 3 Segundos</td> <td>2020-04-21</td> </tr>
+		<tr> <td>mariadb-shard-2</td> <td>sgx-scalable.epc30.large</td> <td>8 Dias, 17 Horas e 44 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>mariadb-shard-1</td> <td>sgx-scalable.epc30.large</td> <td>8 Dias, 17 Horas e 42 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>max-scale</td> <td>sgx-scalable.epc30.large</td> <td>8 Dias, 16 Horas e 43 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>cas</td> <td>sgx.epc16.medium</td> <td>3 Dias, 9 Horas e 22 Segundos</td> <td>2020-04-27</td> </tr>
+		<tr> <td>K8s-misc-tests</td> <td>sgx-scalable.epc30.large</td> <td>2 Dias, 6 Horas e 4 Segundos</td> <td>2020-04-28</td> </tr>
+		<tr> <td>kafka</td> <td>lsd.t1.medium</td> <td>2 Dias, 2 Horas e 45 Segundos</td> <td>2020-04-28</td> </tr>
+		<tr> <td>icelake-benchmark-prep</td> <td>sgx-scalable.epc30.large</td> <td>1 Dias, 3 Horas e 53 Segundos</td> <td>2020-04-29</td> </tr>
 
     </table>
     
@@ -208,16 +208,16 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>kafka-cluster-2</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-12 13:21:28</td> </tr>
-		<tr> <td>kafka-cluster-1</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-12 13:21:29</td> </tr>
-		<tr> <td>zookeeper</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-12 13:30:16</td> </tr>
-		<tr> <td>gitlab-runner</td> <td>lsd.t1.tiny</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-12 13:50:01</td> </tr>
-		<tr> <td>kafka-cluster-3</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-18 12:22:31</td> </tr>
-		<tr> <td>proxy-experiment</td> <td>sgx.epc32.medium</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-13 14:34:43</td> </tr>
-		<tr> <td>dashboard</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-12 18:05:03</td> </tr>
-		<tr> <td>shibboleth</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10 13:31:52</td> </tr>
-		<tr> <td>LuizAugusto-Fisicalização</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-26 14:13:04</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>kafka-cluster-2</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-12</td> </tr>
+		<tr> <td>kafka-cluster-1</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-12</td> </tr>
+		<tr> <td>zookeeper</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-12</td> </tr>
+		<tr> <td>gitlab-runner</td> <td>lsd.t1.tiny</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-12</td> </tr>
+		<tr> <td>kafka-cluster-3</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-18</td> </tr>
+		<tr> <td>proxy-experiment</td> <td>sgx.epc32.medium</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-13</td> </tr>
+		<tr> <td>dashboard</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-12</td> </tr>
+		<tr> <td>shibboleth</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-10</td> </tr>
+		<tr> <td>LuizAugusto-Fisicalização</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-26</td> </tr>
 
     </table>
     
@@ -251,16 +251,16 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>demo-controller</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-21 14:08:18</td> </tr>
-		<tr> <td>demo-controller-leo</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-21 19:14:14</td> </tr>
-		<tr> <td>docker-registry</td> <td>lsd.t1.nano</td> <td>0 Dias, 8 Horas e 9 Segundos</td> <td>2020-04-06 10:52:57</td> </tr>
-		<tr> <td>ztpo-lsd-registry</td> <td>lsd.t1.nano</td> <td>0 Dias, 1 Horas e 24 Segundos</td> <td>2020-04-06 19:55:07</td> </tr>
-		<tr> <td>docker-registry</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 55 Segundos</td> <td>2020-04-06 21:10:59</td> </tr>
-		<tr> <td>docker-registry</td> <td>lsd.t1.nano</td> <td>24 Dias, 1 Horas e 59 Segundos</td> <td>2020-04-06 22:02:01</td> </tr>
-		<tr> <td>tpm-demo</td> <td>lsd.t1.medium</td> <td>21 Dias, 1 Horas e 33 Segundos</td> <td>2020-04-09 22:02:27</td> </tr>
-		<tr> <td>vm-anderson</td> <td>lsd.t1.small</td> <td>17 Dias, 3 Horas e 32 Segundos</td> <td>2020-04-13 20:13:28</td> </tr>
-		<tr> <td>kafka-test</td> <td>lsd.t1.medium</td> <td>7 Dias, 0 Horas e 4 Segundos</td> <td>2020-04-16 14:35:14</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>demo-controller</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-21</td> </tr>
+		<tr> <td>demo-controller-leo</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-21</td> </tr>
+		<tr> <td>docker-registry</td> <td>lsd.t1.nano</td> <td>0 Dias, 8 Horas e 9 Segundos</td> <td>2020-04-06</td> </tr>
+		<tr> <td>ztpo-lsd-registry</td> <td>lsd.t1.nano</td> <td>0 Dias, 1 Horas e 24 Segundos</td> <td>2020-04-06</td> </tr>
+		<tr> <td>docker-registry</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 55 Segundos</td> <td>2020-04-06</td> </tr>
+		<tr> <td>docker-registry</td> <td>lsd.t1.nano</td> <td>24 Dias, 1 Horas e 59 Segundos</td> <td>2020-04-06</td> </tr>
+		<tr> <td>tpm-demo</td> <td>lsd.t1.medium</td> <td>21 Dias, 1 Horas e 33 Segundos</td> <td>2020-04-09</td> </tr>
+		<tr> <td>vm-anderson</td> <td>lsd.t1.small</td> <td>17 Dias, 3 Horas e 32 Segundos</td> <td>2020-04-13</td> </tr>
+		<tr> <td>kafka-test</td> <td>lsd.t1.medium</td> <td>7 Dias, 0 Horas e 4 Segundos</td> <td>2020-04-16</td> </tr>
 
     </table>
     
@@ -292,17 +292,17 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>kafka-server01</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-11 01:19:20</td> </tr>
-		<tr> <td>kafka-server02</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-11 03:47:13</td> </tr>
-		<tr> <td>kafka-server03</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-11 03:47:43</td> </tr>
-		<tr> <td>alpha</td> <td>lsd.t2.xlarge</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-23 13:57:35</td> </tr>
-		<tr> <td>beta</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-24 20:48:36</td> </tr>
-		<tr> <td>silvana</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-27 16:57:02</td> </tr>
-		<tr> <td>set-lsd</td> <td>lsd.t2.xlarge</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-27 18:32:33</td> </tr>
-		<tr> <td>temp-bd</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 31 Segundos</td> <td>2020-04-01 22:04:29</td> </tr>
-		<tr> <td>temp</td> <td>lsd.t2.large</td> <td>15 Dias, 19 Horas e 42 Segundos</td> <td>2020-04-01 22:11:20</td> </tr>
-		<tr> <td>gitlab-ci-runner</td> <td>lsd.t2.large</td> <td>8 Dias, 7 Horas e 7 Segundos</td> <td>2020-04-22 16:24:53</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>kafka-server01</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-11</td> </tr>
+		<tr> <td>kafka-server02</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-11</td> </tr>
+		<tr> <td>kafka-server03</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-11</td> </tr>
+		<tr> <td>alpha</td> <td>lsd.t2.xlarge</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-23</td> </tr>
+		<tr> <td>beta</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-24</td> </tr>
+		<tr> <td>silvana</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-27</td> </tr>
+		<tr> <td>set-lsd</td> <td>lsd.t2.xlarge</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-27</td> </tr>
+		<tr> <td>temp-bd</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 31 Segundos</td> <td>2020-04-01</td> </tr>
+		<tr> <td>temp</td> <td>lsd.t2.large</td> <td>15 Dias, 19 Horas e 42 Segundos</td> <td>2020-04-01</td> </tr>
+		<tr> <td>gitlab-ci-runner</td> <td>lsd.t2.large</td> <td>8 Dias, 7 Horas e 7 Segundos</td> <td>2020-04-22</td> </tr>
 
     </table>
     
@@ -331,7 +331,7 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
 
     </table>
     

--- a/reports/04-2020/campelo@computacao.ufcg.edu.br.html
+++ b/reports/04-2020/campelo@computacao.ufcg.edu.br.html
@@ -31,10 +31,10 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>app1</td> <td>lsd.t2.xlarge</td> <td>0 Dias, 4 Horas e 1 Segundos</td> <td>2020-04-03 14:59:40</td> </tr>
-		<tr> <td>app2</td> <td>lsd.t2.large</td> <td>27 Dias, 4 Horas e 19 Segundos</td> <td>2020-04-03 19:29:41</td> </tr>
-		<tr> <td>app1</td> <td>lsd.t2.xlarge</td> <td>27 Dias, 4 Horas e 48 Segundos</td> <td>2020-04-03 19:41:12</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>app1</td> <td>lsd.t2.xlarge</td> <td>0 Dias, 4 Horas e 1 Segundos</td> <td>2020-04-03</td> </tr>
+		<tr> <td>app2</td> <td>lsd.t2.large</td> <td>27 Dias, 4 Horas e 19 Segundos</td> <td>2020-04-03</td> </tr>
+		<tr> <td>app1</td> <td>lsd.t2.xlarge</td> <td>27 Dias, 4 Horas e 48 Segundos</td> <td>2020-04-03</td> </tr>
 
     </table>
     

--- a/reports/04-2020/cesp@computacao.ufcg.edu.br.html
+++ b/reports/04-2020/cesp@computacao.ufcg.edu.br.html
@@ -31,10 +31,10 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>petrobras</td> <td>lsd.t1.small</td> <td>27 Dias, 2 Horas e 52 Segundos</td> <td>2020-04-03 21:20:08</td> </tr>
-		<tr> <td>petrobras</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 27 Segundos</td> <td>2020-04-03 21:23:00</td> </tr>
-		<tr> <td>petrobras</td> <td>lsd.t1.small</td> <td>27 Dias, 2 Horas e 4 Segundos</td> <td>2020-04-03 21:44:56</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>petrobras</td> <td>lsd.t1.small</td> <td>27 Dias, 2 Horas e 52 Segundos</td> <td>2020-04-03</td> </tr>
+		<tr> <td>petrobras</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 27 Segundos</td> <td>2020-04-03</td> </tr>
+		<tr> <td>petrobras</td> <td>lsd.t1.small</td> <td>27 Dias, 2 Horas e 4 Segundos</td> <td>2020-04-03</td> </tr>
 
     </table>
     

--- a/reports/04-2020/fubica@lsd.ufcg.edu.br.html
+++ b/reports/04-2020/fubica@lsd.ufcg.edu.br.html
@@ -31,8 +31,8 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 22 Segundos</td> <td>2020-04-14 21:50:46</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 22 Segundos</td> <td>2020-04-14</td> </tr>
 
     </table>
     
@@ -60,9 +60,9 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>userimage-ae8eb35e-fc00-11e9-a7f5-caa7cccc8452</td> <td>sgx-fogbow.epc8.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-10-31 17:06:23</td> </tr>
-		<tr> <td>userimage-c0905acc-fc04-11e9-8dd5-fa163e5bdd4c</td> <td>sgx-fogbow.epc8.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-10-31 17:35:29</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>userimage-ae8eb35e-fc00-11e9-a7f5-caa7cccc8452</td> <td>sgx-fogbow.epc8.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-10-31</td> </tr>
+		<tr> <td>userimage-c0905acc-fc04-11e9-8dd5-fa163e5bdd4c</td> <td>sgx-fogbow.epc8.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-10-31</td> </tr>
 
     </table>
     
@@ -90,20 +90,20 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>owncloud</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-11 11:33:49</td> </tr>
-		<tr> <td>worker-1</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-12 18:44:49</td> </tr>
-		<tr> <td>Iguassu Deploy</td> <td>lsd.t1.tiny</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-19 22:09:05</td> </tr>
-		<tr> <td>catalog-test</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-18 15:41:53</td> </tr>
-		<tr> <td>archiver-test</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-20 15:03:51</td> </tr>
-		<tr> <td>arrebol-raonet</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-20 17:54:50</td> </tr>
-		<tr> <td>dispatcher-test</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-24 14:50:48</td> </tr>
-		<tr> <td>arrebol-test</td> <td>lsd.t1.medium</td> <td>14 Dias, 20 Horas e 34 Segundos</td> <td>2020-03-24 22:30:55</td> </tr>
-		<tr> <td>saps-test</td> <td>lsd.t2.large</td> <td>9 Dias, 1 Horas e 20 Segundos</td> <td>2020-04-06 17:55:54</td> </tr>
-		<tr> <td>temp</td> <td>lsd.t1.small</td> <td>6 Dias, 14 Horas e 43 Segundos</td> <td>2020-04-09 04:31:30</td> </tr>
-		<tr> <td>saps-test</td> <td>lsd.t2.large</td> <td>15 Dias, 3 Horas e 44 Segundos</td> <td>2020-04-15 20:03:16</td> </tr>
-		<tr> <td>worker-test</td> <td>lsd.t2.large</td> <td>8 Dias, 5 Horas e 57 Segundos</td> <td>2020-04-22 18:07:03</td> </tr>
-		<tr> <td>worker-test-2</td> <td>lsd.t1.nano</td> <td>0 Dias, 4 Horas e 6 Segundos</td> <td>2020-04-29 14:59:18</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>owncloud</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-11</td> </tr>
+		<tr> <td>worker-1</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-12</td> </tr>
+		<tr> <td>Iguassu Deploy</td> <td>lsd.t1.tiny</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-19</td> </tr>
+		<tr> <td>catalog-test</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-18</td> </tr>
+		<tr> <td>archiver-test</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-20</td> </tr>
+		<tr> <td>arrebol-raonet</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-20</td> </tr>
+		<tr> <td>dispatcher-test</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-24</td> </tr>
+		<tr> <td>arrebol-test</td> <td>lsd.t1.medium</td> <td>14 Dias, 20 Horas e 34 Segundos</td> <td>2020-03-24</td> </tr>
+		<tr> <td>saps-test</td> <td>lsd.t2.large</td> <td>9 Dias, 1 Horas e 20 Segundos</td> <td>2020-04-06</td> </tr>
+		<tr> <td>temp</td> <td>lsd.t1.small</td> <td>6 Dias, 14 Horas e 43 Segundos</td> <td>2020-04-09</td> </tr>
+		<tr> <td>saps-test</td> <td>lsd.t2.large</td> <td>15 Dias, 3 Horas e 44 Segundos</td> <td>2020-04-15</td> </tr>
+		<tr> <td>worker-test</td> <td>lsd.t2.large</td> <td>8 Dias, 5 Horas e 57 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>worker-test-2</td> <td>lsd.t1.nano</td> <td>0 Dias, 4 Horas e 6 Segundos</td> <td>2020-04-29</td> </tr>
 
     </table>
     
@@ -139,38 +139,38 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>sim-relaxed-opt-2</td> <td>lsd.t2.xxlarge</td> <td>2 Dias, 18 Horas e 26 Segundos</td> <td>2019-09-12 01:31:51</td> </tr>
-		<tr> <td>ceph-storage-3</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-07 13:35:21</td> </tr>
-		<tr> <td>ceph-storage-2</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-07 13:35:23</td> </tr>
-		<tr> <td>ceph-storage-1</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-07 13:35:24</td> </tr>
-		<tr> <td>ceph-deploy</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-07 13:43:36</td> </tr>
-		<tr> <td>ceph-client</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-07 13:46:48</td> </tr>
-		<tr> <td>ceph-monitor-3</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-07 13:55:20</td> </tr>
-		<tr> <td>ceph-monitor-1</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-07 13:55:23</td> </tr>
-		<tr> <td>ceph-mds-1</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-07 14:00:23</td> </tr>
-		<tr> <td>ceph-mds-2</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-07 14:00:26</td> </tr>
-		<tr> <td>ceph-monitor-2</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-07 14:35:29</td> </tr>
-		<tr> <td>kubemaster-cloud4</td> <td>lsd.t2.large</td> <td>29 Dias, 10 Horas e 3 Segundos</td> <td>2020-04-01 13:46:57</td> </tr>
-		<tr> <td>kubemaster-cloud4-v2</td> <td>lsd.t2.large</td> <td>0 Dias, 2 Horas e 38 Segundos</td> <td>2020-04-01 18:30:57</td> </tr>
-		<tr> <td>kubeworker1-cloud4</td> <td>lsd.t1.medium_cloudish</td> <td>29 Dias, 2 Horas e 25 Segundos</td> <td>2020-04-01 20:41:46</td> </tr>
-		<tr> <td>kubeworker2-cloud4</td> <td>lsd.t1.medium_cloudish</td> <td>29 Dias, 0 Horas e 41 Segundos</td> <td>2020-04-01 22:53:40</td> </tr>
-		<tr> <td>kubeworker3-cloud4</td> <td>lsd.t1.medium_cloudish</td> <td>27 Dias, 5 Horas e 47 Segundos</td> <td>2020-04-03 18:15:40</td> </tr>
-		<tr> <td>kubeworker4-cloud4</td> <td>lsd.t1.medium_cloudish</td> <td>27 Dias, 5 Horas e 54 Segundos</td> <td>2020-04-03 18:16:46</td> </tr>
-		<tr> <td>kubeworker5-cloud4</td> <td>lsd.t1.medium_cloudish</td> <td>27 Dias, 4 Horas e 44 Segundos</td> <td>2020-04-03 18:17:50</td> </tr>
-		<tr> <td>ceph-deploy</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 9 Segundos</td> <td>2020-04-16 19:33:04</td> </tr>
-		<tr> <td>ceph-deploy-node</td> <td>lsd.t1.small</td> <td>14 Dias, 4 Horas e 38 Segundos</td> <td>2020-04-16 19:36:22</td> </tr>
-		<tr> <td>ceph-master-node</td> <td>lsd.t1.tiny</td> <td>11 Dias, 9 Horas e 51 Segundos</td> <td>2020-04-19 14:46:09</td> </tr>
-		<tr> <td>ceph-storage-node-2</td> <td>lsd.t1.tiny</td> <td>11 Dias, 9 Horas e 58 Segundos</td> <td>2020-04-19 14:48:02</td> </tr>
-		<tr> <td>ceph-storage-node-3</td> <td>lsd.t1.tiny</td> <td>11 Dias, 9 Horas e 52 Segundos</td> <td>2020-04-19 14:48:08</td> </tr>
-		<tr> <td>ceph-storage-node-1</td> <td>lsd.t1.tiny</td> <td>11 Dias, 9 Horas e 52 Segundos</td> <td>2020-04-19 14:48:08</td> </tr>
-		<tr> <td>ceph-client-18</td> <td>lsd.t1.tiny</td> <td>10 Dias, 11 Horas e 20 Segundos</td> <td>2020-04-20 12:22:40</td> </tr>
-		<tr> <td>ceph-client-17</td> <td>lsd.t1.tiny</td> <td>10 Dias, 11 Horas e 13 Segundos</td> <td>2020-04-20 12:33:47</td> </tr>
-		<tr> <td>test-ceph-mm</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 32 Segundos</td> <td>2020-04-22 11:20:07</td> </tr>
-		<tr> <td>test-ceph-mm</td> <td>lsd.t1.tiny</td> <td>8 Dias, 12 Horas e 14 Segundos</td> <td>2020-04-22 11:21:46</td> </tr>
-		<tr> <td>test-ceph-osd</td> <td>lsd.t1.tiny</td> <td>8 Dias, 12 Horas e 23 Segundos</td> <td>2020-04-22 11:22:37</td> </tr>
-		<tr> <td>test-ceph-deploy</td> <td>lsd.t1.tiny</td> <td>8 Dias, 11 Horas e 30 Segundos</td> <td>2020-04-22 12:07:30</td> </tr>
-		<tr> <td>test-manel-bench</td> <td>lsd.t1.small</td> <td>2 Dias, 5 Horas e 44 Segundos</td> <td>2020-04-28 18:54:16</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>sim-relaxed-opt-2</td> <td>lsd.t2.xxlarge</td> <td>2 Dias, 18 Horas e 26 Segundos</td> <td>2019-09-12</td> </tr>
+		<tr> <td>ceph-storage-3</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-07</td> </tr>
+		<tr> <td>ceph-storage-2</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-07</td> </tr>
+		<tr> <td>ceph-storage-1</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-07</td> </tr>
+		<tr> <td>ceph-deploy</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-07</td> </tr>
+		<tr> <td>ceph-client</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-07</td> </tr>
+		<tr> <td>ceph-monitor-3</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-07</td> </tr>
+		<tr> <td>ceph-monitor-1</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-07</td> </tr>
+		<tr> <td>ceph-mds-1</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-07</td> </tr>
+		<tr> <td>ceph-mds-2</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-07</td> </tr>
+		<tr> <td>ceph-monitor-2</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-07</td> </tr>
+		<tr> <td>kubemaster-cloud4</td> <td>lsd.t2.large</td> <td>29 Dias, 10 Horas e 3 Segundos</td> <td>2020-04-01</td> </tr>
+		<tr> <td>kubemaster-cloud4-v2</td> <td>lsd.t2.large</td> <td>0 Dias, 2 Horas e 38 Segundos</td> <td>2020-04-01</td> </tr>
+		<tr> <td>kubeworker1-cloud4</td> <td>lsd.t1.medium_cloudish</td> <td>29 Dias, 2 Horas e 25 Segundos</td> <td>2020-04-01</td> </tr>
+		<tr> <td>kubeworker2-cloud4</td> <td>lsd.t1.medium_cloudish</td> <td>29 Dias, 0 Horas e 41 Segundos</td> <td>2020-04-01</td> </tr>
+		<tr> <td>kubeworker3-cloud4</td> <td>lsd.t1.medium_cloudish</td> <td>27 Dias, 5 Horas e 47 Segundos</td> <td>2020-04-03</td> </tr>
+		<tr> <td>kubeworker4-cloud4</td> <td>lsd.t1.medium_cloudish</td> <td>27 Dias, 5 Horas e 54 Segundos</td> <td>2020-04-03</td> </tr>
+		<tr> <td>kubeworker5-cloud4</td> <td>lsd.t1.medium_cloudish</td> <td>27 Dias, 4 Horas e 44 Segundos</td> <td>2020-04-03</td> </tr>
+		<tr> <td>ceph-deploy</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 9 Segundos</td> <td>2020-04-16</td> </tr>
+		<tr> <td>ceph-deploy-node</td> <td>lsd.t1.small</td> <td>14 Dias, 4 Horas e 38 Segundos</td> <td>2020-04-16</td> </tr>
+		<tr> <td>ceph-master-node</td> <td>lsd.t1.tiny</td> <td>11 Dias, 9 Horas e 51 Segundos</td> <td>2020-04-19</td> </tr>
+		<tr> <td>ceph-storage-node-2</td> <td>lsd.t1.tiny</td> <td>11 Dias, 9 Horas e 58 Segundos</td> <td>2020-04-19</td> </tr>
+		<tr> <td>ceph-storage-node-3</td> <td>lsd.t1.tiny</td> <td>11 Dias, 9 Horas e 52 Segundos</td> <td>2020-04-19</td> </tr>
+		<tr> <td>ceph-storage-node-1</td> <td>lsd.t1.tiny</td> <td>11 Dias, 9 Horas e 52 Segundos</td> <td>2020-04-19</td> </tr>
+		<tr> <td>ceph-client-18</td> <td>lsd.t1.tiny</td> <td>10 Dias, 11 Horas e 20 Segundos</td> <td>2020-04-20</td> </tr>
+		<tr> <td>ceph-client-17</td> <td>lsd.t1.tiny</td> <td>10 Dias, 11 Horas e 13 Segundos</td> <td>2020-04-20</td> </tr>
+		<tr> <td>test-ceph-mm</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 32 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test-ceph-mm</td> <td>lsd.t1.tiny</td> <td>8 Dias, 12 Horas e 14 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test-ceph-osd</td> <td>lsd.t1.tiny</td> <td>8 Dias, 12 Horas e 23 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test-ceph-deploy</td> <td>lsd.t1.tiny</td> <td>8 Dias, 11 Horas e 30 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test-manel-bench</td> <td>lsd.t1.small</td> <td>2 Dias, 5 Horas e 44 Segundos</td> <td>2020-04-28</td> </tr>
 
     </table>
     
@@ -202,22 +202,22 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>vm-test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-16 17:49:55</td> </tr>
-		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 21 Segundos</td> <td>2020-04-14 22:36:38</td> </tr>
-		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 22 Segundos</td> <td>2020-04-22 01:15:28</td> </tr>
-		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 15 Segundos</td> <td>2020-04-22 01:41:35</td> </tr>
-		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 15 Segundos</td> <td>2020-04-22 01:44:18</td> </tr>
-		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 8 Segundos</td> <td>2020-04-22 11:16:36</td> </tr>
-		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 28 Segundos</td> <td>2020-04-22 11:25:53</td> </tr>
-		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 18 Segundos</td> <td>2020-04-22 11:35:52</td> </tr>
-		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 17 Segundos</td> <td>2020-04-22 12:57:16</td> </tr>
-		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 39 Segundos</td> <td>2020-04-22 13:24:05</td> </tr>
-		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 15 Segundos</td> <td>2020-04-29 17:17:48</td> </tr>
-		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 38 Segundos</td> <td>2020-04-29 17:19:41</td> </tr>
-		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-03 23:01:12</td> </tr>
-		<tr> <td>site3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-03 23:01:44</td> </tr>
-		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04 01:44:41</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>vm-test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-16</td> </tr>
+		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 21 Segundos</td> <td>2020-04-14</td> </tr>
+		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 22 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 15 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 15 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 8 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 28 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 18 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 17 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 39 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 15 Segundos</td> <td>2020-04-29</td> </tr>
+		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 38 Segundos</td> <td>2020-04-29</td> </tr>
+		<tr> <td>test1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-03</td> </tr>
+		<tr> <td>site3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-03</td> </tr>
+		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04</td> </tr>
 
     </table>
     
@@ -245,13 +245,13 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>deployment-machine</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-08 14:06:06</td> </tr>
-		<tr> <td>member1 (xmpp test machine)</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-08 17:49:37</td> </tr>
-		<tr> <td>member2 (xmpp test machine)</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-08 17:57:12</td> </tr>
-		<tr> <td>w1</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-25 01:48:03</td> </tr>
-		<tr> <td>w2</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-25 14:49:52</td> </tr>
-		<tr> <td>w3</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-25 14:50:30</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>deployment-machine</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-08</td> </tr>
+		<tr> <td>member1 (xmpp test machine)</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-08</td> </tr>
+		<tr> <td>member2 (xmpp test machine)</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-08</td> </tr>
+		<tr> <td>w1</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-25</td> </tr>
+		<tr> <td>w2</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-25</td> </tr>
+		<tr> <td>w3</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-25</td> </tr>
 
     </table>
     
@@ -280,7 +280,7 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
 
     </table>
     
@@ -307,20 +307,20 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>internal-atm-prod</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-06-04 14:59:10</td> </tr>
-		<tr> <td>dmz-atm-prod</td> <td>lsd.t1.tiny</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-06-04 14:59:10</td> </tr>
-		<tr> <td>cloud-broker</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-06-14 19:52:41</td> </tr>
-		<tr> <td>cloudburst</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-06-14 20:14:48</td> </tr>
-		<tr> <td>vlanId-service</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-07-12 15:06:45</td> </tr>
-		<tr> <td>atm-test-site2</td> <td>lsd.t2.large</td> <td>25 Dias, 13 Horas e 34 Segundos</td> <td>2019-07-25 17:00:50</td> </tr>
-		<tr> <td>atm-test-site3</td> <td>lsd.t2.large</td> <td>22 Dias, 8 Horas e 35 Segundos</td> <td>2019-07-25 17:02:05</td> </tr>
-		<tr> <td>xmpp-atm-test-site2</td> <td>lsd.t1.tiny</td> <td>27 Dias, 23 Horas e 48 Segundos</td> <td>2019-10-18 12:15:24</td> </tr>
-		<tr> <td>xmpp-atm-test-site3</td> <td>lsd.t1.tiny</td> <td>22 Dias, 8 Horas e 30 Segundos</td> <td>2019-10-18 12:40:25</td> </tr>
-		<tr> <td>xmpp-services-commune</td> <td>lsd.t1.tiny</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-10-24 10:32:25</td> </tr>
-		<tr> <td>services-commune</td> <td>lsd.t1.medium</td> <td>29 Dias, 23 Horas e 21 Segundos</td> <td>2019-10-24 17:55:24</td> </tr>
-		<tr> <td>atm-test-site1</td> <td>lsd.t1.medium</td> <td>29 Dias, 23 Horas e 54 Segundos</td> <td>2019-11-06 19:38:01</td> </tr>
-		<tr> <td>xmpp-atm-test-site1</td> <td>lsd.t1.tiny</td> <td>22 Dias, 8 Horas e 5 Segundos</td> <td>2019-11-06 19:39:24</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>internal-atm-prod</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-06-04</td> </tr>
+		<tr> <td>dmz-atm-prod</td> <td>lsd.t1.tiny</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-06-04</td> </tr>
+		<tr> <td>cloud-broker</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-06-14</td> </tr>
+		<tr> <td>cloudburst</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-06-14</td> </tr>
+		<tr> <td>vlanId-service</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-07-12</td> </tr>
+		<tr> <td>atm-test-site2</td> <td>lsd.t2.large</td> <td>25 Dias, 13 Horas e 34 Segundos</td> <td>2019-07-25</td> </tr>
+		<tr> <td>atm-test-site3</td> <td>lsd.t2.large</td> <td>22 Dias, 8 Horas e 35 Segundos</td> <td>2019-07-25</td> </tr>
+		<tr> <td>xmpp-atm-test-site2</td> <td>lsd.t1.tiny</td> <td>27 Dias, 23 Horas e 48 Segundos</td> <td>2019-10-18</td> </tr>
+		<tr> <td>xmpp-atm-test-site3</td> <td>lsd.t1.tiny</td> <td>22 Dias, 8 Horas e 30 Segundos</td> <td>2019-10-18</td> </tr>
+		<tr> <td>xmpp-services-commune</td> <td>lsd.t1.tiny</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-10-24</td> </tr>
+		<tr> <td>services-commune</td> <td>lsd.t1.medium</td> <td>29 Dias, 23 Horas e 21 Segundos</td> <td>2019-10-24</td> </tr>
+		<tr> <td>atm-test-site1</td> <td>lsd.t1.medium</td> <td>29 Dias, 23 Horas e 54 Segundos</td> <td>2019-11-06</td> </tr>
+		<tr> <td>xmpp-atm-test-site1</td> <td>lsd.t1.tiny</td> <td>22 Dias, 8 Horas e 5 Segundos</td> <td>2019-11-06</td> </tr>
 
     </table>
     
@@ -351,19 +351,19 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>Opennebula -  MiniOne</td> <td>lsd.t2.large</td> <td>0 Dias, 19 Horas e 27 Segundos</td> <td>2020-04-01 18:03:36</td> </tr>
-		<tr> <td>Opennebula - Minione</td> <td>lsd.t2.xlarge</td> <td>0 Dias, 3 Horas e 31 Segundos</td> <td>2020-04-02 13:49:02</td> </tr>
-		<tr> <td>Opennebula - MiniOne</td> <td>lsd.t2.large</td> <td>0 Dias, 21 Horas e 53 Segundos</td> <td>2020-04-02 17:00:57</td> </tr>
-		<tr> <td>Opennebula - Default  - Master</td> <td>lsd.t1.medium</td> <td>4 Dias, 18 Horas e 22 Segundos</td> <td>2020-04-02 17:33:04</td> </tr>
-		<tr> <td>Opennebula - MiniOne</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 28 Segundos</td> <td>2020-04-03 14:06:03</td> </tr>
-		<tr> <td>Opennebula - MiniOne</td> <td>lsd.t2.large</td> <td>10 Dias, 23 Horas e 57 Segundos</td> <td>2020-04-03 14:34:24</td> </tr>
-		<tr> <td>Opennebula - MiniOne 5.6</td> <td>lsd.t2.large</td> <td>0 Dias, 1 Horas e 12 Segundos</td> <td>2020-04-07 12:03:10</td> </tr>
-		<tr> <td>Opennebula - MiniOne - 5.6</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 57 Segundos</td> <td>2020-04-07 13:06:38</td> </tr>
-		<tr> <td>Opennebula - Manual - Sunstone</td> <td>lsd.t2.large</td> <td>5 Dias, 22 Horas e 24 Segundos</td> <td>2020-04-07 14:18:42</td> </tr>
-		<tr> <td>Opennebula - Minione Two</td> <td>lsd.t2.large</td> <td>17 Dias, 11 Horas e 55 Segundos</td> <td>2020-04-13 12:38:05</td> </tr>
-		<tr> <td>Opennebula - Front</td> <td>lsd.t1.medium</td> <td>16 Dias, 9 Horas e 15 Segundos</td> <td>2020-04-14 14:18:45</td> </tr>
-		<tr> <td>Opennebula - Node</td> <td>lsd.t1.medium</td> <td>16 Dias, 9 Horas e 34 Segundos</td> <td>2020-04-14 14:42:26</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>Opennebula -  MiniOne</td> <td>lsd.t2.large</td> <td>0 Dias, 19 Horas e 27 Segundos</td> <td>2020-04-01</td> </tr>
+		<tr> <td>Opennebula - Minione</td> <td>lsd.t2.xlarge</td> <td>0 Dias, 3 Horas e 31 Segundos</td> <td>2020-04-02</td> </tr>
+		<tr> <td>Opennebula - MiniOne</td> <td>lsd.t2.large</td> <td>0 Dias, 21 Horas e 53 Segundos</td> <td>2020-04-02</td> </tr>
+		<tr> <td>Opennebula - Default  - Master</td> <td>lsd.t1.medium</td> <td>4 Dias, 18 Horas e 22 Segundos</td> <td>2020-04-02</td> </tr>
+		<tr> <td>Opennebula - MiniOne</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 28 Segundos</td> <td>2020-04-03</td> </tr>
+		<tr> <td>Opennebula - MiniOne</td> <td>lsd.t2.large</td> <td>10 Dias, 23 Horas e 57 Segundos</td> <td>2020-04-03</td> </tr>
+		<tr> <td>Opennebula - MiniOne 5.6</td> <td>lsd.t2.large</td> <td>0 Dias, 1 Horas e 12 Segundos</td> <td>2020-04-07</td> </tr>
+		<tr> <td>Opennebula - MiniOne - 5.6</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 57 Segundos</td> <td>2020-04-07</td> </tr>
+		<tr> <td>Opennebula - Manual - Sunstone</td> <td>lsd.t2.large</td> <td>5 Dias, 22 Horas e 24 Segundos</td> <td>2020-04-07</td> </tr>
+		<tr> <td>Opennebula - Minione Two</td> <td>lsd.t2.large</td> <td>17 Dias, 11 Horas e 55 Segundos</td> <td>2020-04-13</td> </tr>
+		<tr> <td>Opennebula - Front</td> <td>lsd.t1.medium</td> <td>16 Dias, 9 Horas e 15 Segundos</td> <td>2020-04-14</td> </tr>
+		<tr> <td>Opennebula - Node</td> <td>lsd.t1.medium</td> <td>16 Dias, 9 Horas e 34 Segundos</td> <td>2020-04-14</td> </tr>
 
     </table>
     
@@ -393,24 +393,24 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>saps-frontpage</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-11 11:48:55</td> </tr>
-		<tr> <td>saps-catalog-dashboard-dispatcher</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-11 12:32:01</td> </tr>
-		<tr> <td>saps-scheduler</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-12 18:41:39</td> </tr>
-		<tr> <td>saps-archiver</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-12 18:43:19</td> </tr>
-		<tr> <td>saps-worker-l3-1</td> <td>lsd.t2.xlarge_2</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-12-18 13:26:50</td> </tr>
-		<tr> <td>saps-worker-l3-3</td> <td>lsd.t2.xlarge_2</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-12-18 13:26:52</td> </tr>
-		<tr> <td>saps-worker-l3-2</td> <td>lsd.t2.xlarge_2</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-12-18 13:26:52</td> </tr>
-		<tr> <td>saps-arrebol-biggest</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-21 13:37:55</td> </tr>
-		<tr> <td>worker-test</td> <td>lsd.t1.medium</td> <td>26 Dias, 13 Horas e 21 Segundos</td> <td>2020-03-25 13:38:23</td> </tr>
-		<tr> <td>scheduler-test</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-25 13:54:40</td> </tr>
-		<tr> <td>dashboard-test</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-25 14:37:04</td> </tr>
-		<tr> <td>arrebol-test</td> <td>lsd.t1.small</td> <td>14 Dias, 23 Horas e 6 Segundos</td> <td>2020-04-15 19:41:40</td> </tr>
-		<tr> <td>get-digest-test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 48 Segundos</td> <td>2020-04-16 19:09:27</td> </tr>
-		<tr> <td>arrebol-test</td> <td>lsd.t1.small</td> <td>0 Dias, 5 Horas e 44 Segundos</td> <td>2020-04-30 18:54:16</td> </tr>
-		<tr> <td>arrebol-test-2</td> <td>lsd.t1.medium</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04 14:47:51</td> </tr>
-		<tr> <td>worker-saps-test</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05 03:16:18</td> </tr>
-		<tr> <td>worker-saps-test</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05 04:55:38</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>saps-frontpage</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-11</td> </tr>
+		<tr> <td>saps-catalog-dashboard-dispatcher</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-11</td> </tr>
+		<tr> <td>saps-scheduler</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-12</td> </tr>
+		<tr> <td>saps-archiver</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-12</td> </tr>
+		<tr> <td>saps-worker-l3-1</td> <td>lsd.t2.xlarge_2</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-12-18</td> </tr>
+		<tr> <td>saps-worker-l3-3</td> <td>lsd.t2.xlarge_2</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-12-18</td> </tr>
+		<tr> <td>saps-worker-l3-2</td> <td>lsd.t2.xlarge_2</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-12-18</td> </tr>
+		<tr> <td>saps-arrebol-biggest</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-21</td> </tr>
+		<tr> <td>worker-test</td> <td>lsd.t1.medium</td> <td>26 Dias, 13 Horas e 21 Segundos</td> <td>2020-03-25</td> </tr>
+		<tr> <td>scheduler-test</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-25</td> </tr>
+		<tr> <td>dashboard-test</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-25</td> </tr>
+		<tr> <td>arrebol-test</td> <td>lsd.t1.small</td> <td>14 Dias, 23 Horas e 6 Segundos</td> <td>2020-04-15</td> </tr>
+		<tr> <td>get-digest-test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 48 Segundos</td> <td>2020-04-16</td> </tr>
+		<tr> <td>arrebol-test</td> <td>lsd.t1.small</td> <td>0 Dias, 5 Horas e 44 Segundos</td> <td>2020-04-30</td> </tr>
+		<tr> <td>arrebol-test-2</td> <td>lsd.t1.medium</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04</td> </tr>
+		<tr> <td>worker-saps-test</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05</td> </tr>
+		<tr> <td>worker-saps-test</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05</td> </tr>
 
     </table>
     
@@ -443,34 +443,34 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 25 Segundos</td> <td>2020-04-14 22:39:34</td> </tr>
-		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 37 Segundos</td> <td>2020-04-21 18:34:27</td> </tr>
-		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 6 Segundos</td> <td>2020-04-21 18:38:29</td> </tr>
-		<tr> <td>test2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 17 Segundos</td> <td>2020-04-21 18:39:00</td> </tr>
-		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 25 Segundos</td> <td>2020-04-21 23:57:21</td> </tr>
-		<tr> <td>test2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 59 Segundos</td> <td>2020-04-21 23:57:51</td> </tr>
-		<tr> <td>test2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 32 Segundos</td> <td>2020-04-22 01:39:19</td> </tr>
-		<tr> <td>test2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 47 Segundos</td> <td>2020-04-22 11:18:01</td> </tr>
-		<tr> <td>test2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 32 Segundos</td> <td>2020-04-22 11:24:47</td> </tr>
-		<tr> <td>test2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 50 Segundos</td> <td>2020-04-22 11:35:26</td> </tr>
-		<tr> <td>test2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 21 Segundos</td> <td>2020-04-22 12:57:07</td> </tr>
-		<tr> <td>test2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 27 Segundos</td> <td>2020-04-22 13:24:18</td> </tr>
-		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 58 Segundos</td> <td>2020-04-23 20:56:29</td> </tr>
-		<tr> <td>direto</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 2 Segundos</td> <td>2020-04-23 20:58:36</td> </tr>
-		<tr> <td>test-hor</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 59 Segundos</td> <td>2020-04-29 15:53:18</td> </tr>
-		<tr> <td>my compute</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 50 Segundos</td> <td>2020-04-29 18:56:35</td> </tr>
-		<tr> <td>site2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 41 Segundos</td> <td>2020-04-29 20:59:21</td> </tr>
-		<tr> <td>test-restart</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 11 Segundos</td> <td>2020-04-29 21:13:02</td> </tr>
-		<tr> <td>test-restart</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-01 01:53:44</td> </tr>
-		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-02 20:49:50</td> </tr>
-		<tr> <td>h1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-03 15:06:15</td> </tr>
-		<tr> <td>h2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-03 15:07:19</td> </tr>
-		<tr> <td>h3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-03 15:16:46</td> </tr>
-		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-03 19:29:04</td> </tr>
-		<tr> <td>test-fednet</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-03 19:45:30</td> </tr>
-		<tr> <td>test-fednet</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-03 19:57:41</td> </tr>
-		<tr> <td>site2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-03 23:01:33</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 25 Segundos</td> <td>2020-04-14</td> </tr>
+		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 37 Segundos</td> <td>2020-04-21</td> </tr>
+		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 6 Segundos</td> <td>2020-04-21</td> </tr>
+		<tr> <td>test2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 17 Segundos</td> <td>2020-04-21</td> </tr>
+		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 25 Segundos</td> <td>2020-04-21</td> </tr>
+		<tr> <td>test2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 59 Segundos</td> <td>2020-04-21</td> </tr>
+		<tr> <td>test2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 32 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 47 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 32 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 50 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 21 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 27 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 58 Segundos</td> <td>2020-04-23</td> </tr>
+		<tr> <td>direto</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 2 Segundos</td> <td>2020-04-23</td> </tr>
+		<tr> <td>test-hor</td> <td>lsd.t1.tiny</td> <td>0 Dias, 0 Horas e 59 Segundos</td> <td>2020-04-29</td> </tr>
+		<tr> <td>my compute</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 50 Segundos</td> <td>2020-04-29</td> </tr>
+		<tr> <td>site2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 41 Segundos</td> <td>2020-04-29</td> </tr>
+		<tr> <td>test-restart</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 11 Segundos</td> <td>2020-04-29</td> </tr>
+		<tr> <td>test-restart</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-01</td> </tr>
+		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-02</td> </tr>
+		<tr> <td>h1</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-03</td> </tr>
+		<tr> <td>h2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-03</td> </tr>
+		<tr> <td>h3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-03</td> </tr>
+		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-03</td> </tr>
+		<tr> <td>test-fednet</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-03</td> </tr>
+		<tr> <td>test-fednet</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-03</td> </tr>
+		<tr> <td>site2</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-03</td> </tr>
 
     </table>
     
@@ -500,7 +500,7 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
 
     </table>
     
@@ -527,18 +527,18 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>worker-node</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-08 18:14:23</td> </tr>
-		<tr> <td>test3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 32 Segundos</td> <td>2020-04-22 01:15:17</td> </tr>
-		<tr> <td>test3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 54 Segundos</td> <td>2020-04-22 01:35:09</td> </tr>
-		<tr> <td>test3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 36 Segundos</td> <td>2020-04-22 01:42:38</td> </tr>
-		<tr> <td>test3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 53 Segundos</td> <td>2020-04-22 11:21:58</td> </tr>
-		<tr> <td>test3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 29 Segundos</td> <td>2020-04-22 11:26:54</td> </tr>
-		<tr> <td>test3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 12 Segundos</td> <td>2020-04-22 11:35:02</td> </tr>
-		<tr> <td>test3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 2 Segundos</td> <td>2020-04-22 12:57:29</td> </tr>
-		<tr> <td>test3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 19 Segundos</td> <td>2020-04-22 13:24:28</td> </tr>
-		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 46 Segundos</td> <td>2020-04-29 17:17:16</td> </tr>
-		<tr> <td>test3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 32 Segundos</td> <td>2020-04-29 17:22:07</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>worker-node</td> <td>lsd.t1.small</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-08</td> </tr>
+		<tr> <td>test3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 32 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 54 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 36 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 53 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 29 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 12 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 2 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 19 Segundos</td> <td>2020-04-22</td> </tr>
+		<tr> <td>test</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 46 Segundos</td> <td>2020-04-29</td> </tr>
+		<tr> <td>test3</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 32 Segundos</td> <td>2020-04-29</td> </tr>
 
     </table>
     

--- a/reports/04-2020/joabsilva@lsd.ufcg.edu.br.html
+++ b/reports/04-2020/joabsilva@lsd.ufcg.edu.br.html
@@ -34,7 +34,7 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
 
     </table>
     
@@ -62,103 +62,103 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>teste-compute22-4</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 55 Segundos</td> <td>2020-04-18 22:38:00</td> </tr>
-		<tr> <td>teste-compute22-5</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 53 Segundos</td> <td>2020-04-18 22:38:00</td> </tr>
-		<tr> <td>teste-compute22-6</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 55 Segundos</td> <td>2020-04-18 22:38:00</td> </tr>
-		<tr> <td>teste-compute22-3</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 57 Segundos</td> <td>2020-04-18 22:38:01</td> </tr>
-		<tr> <td>teste-compute22-1</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 56 Segundos</td> <td>2020-04-18 22:38:01</td> </tr>
-		<tr> <td>teste-compute22-9</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 43 Segundos</td> <td>2020-04-18 22:38:07</td> </tr>
-		<tr> <td>teste-compute22-7</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 50 Segundos</td> <td>2020-04-18 22:38:08</td> </tr>
-		<tr> <td>teste-compute22-8</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 43 Segundos</td> <td>2020-04-18 22:38:08</td> </tr>
-		<tr> <td>teste-compute22-10</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 44 Segundos</td> <td>2020-04-18 22:38:08</td> </tr>
-		<tr> <td>teste-compute22-2</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 46 Segundos</td> <td>2020-04-18 22:38:08</td> </tr>
-		<tr> <td>teste-compute22-11</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 25 Segundos</td> <td>2020-04-18 22:38:27</td> </tr>
-		<tr> <td>teste-compute22-12</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 21 Segundos</td> <td>2020-04-18 22:38:30</td> </tr>
-		<tr> <td>teste-compute22-13</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 19 Segundos</td> <td>2020-04-18 22:38:35</td> </tr>
-		<tr> <td>teste-compute22-14</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 15 Segundos</td> <td>2020-04-18 22:38:37</td> </tr>
-		<tr> <td>teste-compute22-15</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 10 Segundos</td> <td>2020-04-18 22:38:38</td> </tr>
-		<tr> <td>teste-compute22-16</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 10 Segundos</td> <td>2020-04-18 22:38:39</td> </tr>
-		<tr> <td>teste-compute22-17</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 7 Segundos</td> <td>2020-04-18 22:38:39</td> </tr>
-		<tr> <td>teste-compute22-19</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 1 Segundos</td> <td>2020-04-18 22:38:42</td> </tr>
-		<tr> <td>teste-compute22-18</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 2 Segundos</td> <td>2020-04-18 22:38:42</td> </tr>
-		<tr> <td>teste-compute22-20</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 3 Segundos</td> <td>2020-04-18 22:38:42</td> </tr>
-		<tr> <td>teste-compute22-1</td> <td>maintenance</td> <td>1 Dias, 15 Horas e 11 Segundos</td> <td>2020-04-18 22:44:10</td> </tr>
-		<tr> <td>teste-compute22-2</td> <td>maintenance</td> <td>1 Dias, 15 Horas e 6 Segundos</td> <td>2020-04-18 22:44:15</td> </tr>
-		<tr> <td>teste-compute22-3</td> <td>maintenance</td> <td>1 Dias, 15 Horas e 4 Segundos</td> <td>2020-04-18 22:44:16</td> </tr>
-		<tr> <td>teste-compute22-4</td> <td>maintenance</td> <td>1 Dias, 15 Horas e 58 Segundos</td> <td>2020-04-18 22:44:20</td> </tr>
-		<tr> <td>teste-compute22-5</td> <td>maintenance</td> <td>1 Dias, 15 Horas e 56 Segundos</td> <td>2020-04-18 22:44:23</td> </tr>
-		<tr> <td>teste-compute22-6</td> <td>maintenance</td> <td>1 Dias, 15 Horas e 56 Segundos</td> <td>2020-04-18 22:44:24</td> </tr>
-		<tr> <td>teste-compute22-9</td> <td>maintenance</td> <td>1 Dias, 15 Horas e 50 Segundos</td> <td>2020-04-18 22:44:26</td> </tr>
-		<tr> <td>teste-compute22-7</td> <td>maintenance</td> <td>1 Dias, 15 Horas e 52 Segundos</td> <td>2020-04-18 22:44:26</td> </tr>
-		<tr> <td>teste-compute22-8</td> <td>maintenance</td> <td>1 Dias, 15 Horas e 53 Segundos</td> <td>2020-04-18 22:44:26</td> </tr>
-		<tr> <td>teste-compute22-10</td> <td>maintenance</td> <td>1 Dias, 15 Horas e 51 Segundos</td> <td>2020-04-18 22:44:26</td> </tr>
-		<tr> <td>teste-compute23-3</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 3 Segundos</td> <td>2020-04-18 23:20:09</td> </tr>
-		<tr> <td>teste-compute23-2</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 4 Segundos</td> <td>2020-04-18 23:20:09</td> </tr>
-		<tr> <td>teste-compute23-4</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 2 Segundos</td> <td>2020-04-18 23:20:10</td> </tr>
-		<tr> <td>teste-compute23-6</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 59 Segundos</td> <td>2020-04-18 23:20:10</td> </tr>
-		<tr> <td>teste-compute23-1</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 59 Segundos</td> <td>2020-04-18 23:20:12</td> </tr>
-		<tr> <td>teste-compute23-7</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 57 Segundos</td> <td>2020-04-18 23:20:15</td> </tr>
-		<tr> <td>teste-compute23-8</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 56 Segundos</td> <td>2020-04-18 23:20:15</td> </tr>
-		<tr> <td>teste-compute23-5</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 58 Segundos</td> <td>2020-04-18 23:20:15</td> </tr>
-		<tr> <td>teste-compute23-10</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 53 Segundos</td> <td>2020-04-18 23:20:16</td> </tr>
-		<tr> <td>teste-compute23-9</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 54 Segundos</td> <td>2020-04-18 23:20:16</td> </tr>
-		<tr> <td>teste-compute24</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 33 Segundos</td> <td>2020-04-18 23:34:06</td> </tr>
-		<tr> <td>teste-compute24-1</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 14 Segundos</td> <td>2020-04-18 23:41:14</td> </tr>
-		<tr> <td>teste-compute24-2</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 12 Segundos</td> <td>2020-04-18 23:41:17</td> </tr>
-		<tr> <td>teste-compute24-3</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 8 Segundos</td> <td>2020-04-18 23:41:18</td> </tr>
-		<tr> <td>teste-compute24-5</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 4 Segundos</td> <td>2020-04-18 23:41:25</td> </tr>
-		<tr> <td>teste-compute24-7</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 2 Segundos</td> <td>2020-04-18 23:41:26</td> </tr>
-		<tr> <td>teste-compute24-4</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 2 Segundos</td> <td>2020-04-18 23:41:26</td> </tr>
-		<tr> <td>teste-compute24-9</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 57 Segundos</td> <td>2020-04-18 23:41:27</td> </tr>
-		<tr> <td>teste-compute24-8</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 2 Segundos</td> <td>2020-04-18 23:41:27</td> </tr>
-		<tr> <td>teste-compute24-10</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 59 Segundos</td> <td>2020-04-18 23:41:27</td> </tr>
-		<tr> <td>teste-compute24-6</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 58 Segundos</td> <td>2020-04-18 23:41:29</td> </tr>
-		<tr> <td>teste-compute25-2</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 43 Segundos</td> <td>2020-04-18 23:47:42</td> </tr>
-		<tr> <td>teste-compute25-3</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 34 Segundos</td> <td>2020-04-18 23:47:45</td> </tr>
-		<tr> <td>teste-compute25-4</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 41 Segundos</td> <td>2020-04-18 23:47:46</td> </tr>
-		<tr> <td>teste-compute25-1</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 40 Segundos</td> <td>2020-04-18 23:47:46</td> </tr>
-		<tr> <td>teste-compute25-6</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 37 Segundos</td> <td>2020-04-18 23:47:49</td> </tr>
-		<tr> <td>teste-compute25-7</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 26 Segundos</td> <td>2020-04-18 23:47:54</td> </tr>
-		<tr> <td>teste-compute25-8</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 28 Segundos</td> <td>2020-04-18 23:47:54</td> </tr>
-		<tr> <td>teste-compute25-9</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 26 Segundos</td> <td>2020-04-18 23:47:55</td> </tr>
-		<tr> <td>teste-compute25-5</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 26 Segundos</td> <td>2020-04-18 23:47:55</td> </tr>
-		<tr> <td>teste-compute25-10</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 23 Segundos</td> <td>2020-04-18 23:47:55</td> </tr>
-		<tr> <td>Billing-test</td> <td>rally.t1.medium</td> <td>2 Dias, 20 Horas e 56 Segundos</td> <td>2020-04-27 01:39:18</td> </tr>
-		<tr> <td>teste-2</td> <td>maintenance2</td> <td>2 Dias, 2 Horas e 1 Segundos</td> <td>2020-04-27 14:35:18</td> </tr>
-		<tr> <td>teste-3</td> <td>maintenance2</td> <td>2 Dias, 2 Horas e 56 Segundos</td> <td>2020-04-27 14:35:19</td> </tr>
-		<tr> <td>teste-1</td> <td>maintenance2</td> <td>2 Dias, 2 Horas e 0 Segundos</td> <td>2020-04-27 14:35:20</td> </tr>
-		<tr> <td>teste-5</td> <td>maintenance2</td> <td>2 Dias, 2 Horas e 58 Segundos</td> <td>2020-04-27 14:35:20</td> </tr>
-		<tr> <td>teste-4</td> <td>maintenance2</td> <td>2 Dias, 2 Horas e 57 Segundos</td> <td>2020-04-27 14:35:20</td> </tr>
-		<tr> <td>teste-10</td> <td>maintenance2</td> <td>2 Dias, 2 Horas e 42 Segundos</td> <td>2020-04-27 14:35:30</td> </tr>
-		<tr> <td>teste-7</td> <td>maintenance2</td> <td>2 Dias, 2 Horas e 49 Segundos</td> <td>2020-04-27 14:35:30</td> </tr>
-		<tr> <td>teste-6</td> <td>maintenance2</td> <td>2 Dias, 2 Horas e 47 Segundos</td> <td>2020-04-27 14:35:30</td> </tr>
-		<tr> <td>teste-8</td> <td>maintenance2</td> <td>2 Dias, 2 Horas e 42 Segundos</td> <td>2020-04-27 14:35:30</td> </tr>
-		<tr> <td>teste-9</td> <td>maintenance2</td> <td>2 Dias, 2 Horas e 48 Segundos</td> <td>2020-04-27 14:35:30</td> </tr>
-		<tr> <td>Billing-test-2</td> <td>rally.t1.medium</td> <td>0 Dias, 23 Horas e 35 Segundos</td> <td>2020-04-30 00:19:12</td> </tr>
-		<tr> <td>teste-compute-sgx-2</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04 20:04:56</td> </tr>
-		<tr> <td>teste-compute-sgx-3</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04 20:04:57</td> </tr>
-		<tr> <td>teste-compute-sgx-1</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04 20:04:57</td> </tr>
-		<tr> <td>teste-compute-sgx-4</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04 20:05:00</td> </tr>
-		<tr> <td>teste-compute-sgx-6</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04 20:05:01</td> </tr>
-		<tr> <td>teste-compute-sgx-5</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04 20:05:02</td> </tr>
-		<tr> <td>teste-compute-sgx-7</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04 20:05:02</td> </tr>
-		<tr> <td>teste-compute-sgx-9</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04 20:05:05</td> </tr>
-		<tr> <td>teste-compute-sgx-8</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04 20:05:05</td> </tr>
-		<tr> <td>teste-compute-sgx-10</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04 20:05:06</td> </tr>
-		<tr> <td>teste-compute5-sgx-1</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04 20:09:16</td> </tr>
-		<tr> <td>test-c5-compute5-sgx-1</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04 20:24:53</td> </tr>
-		<tr> <td>tes-c5sgxcompute5-1</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04 20:28:17</td> </tr>
-		<tr> <td>teste-sgxcompute6--1</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05 00:47:40</td> </tr>
-		<tr> <td>teste-sgxcompute6--4</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05 00:47:43</td> </tr>
-		<tr> <td>teste-sgxcompute6--3</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05 00:47:45</td> </tr>
-		<tr> <td>teste-sgxcompute6--2</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05 00:47:45</td> </tr>
-		<tr> <td>teste-sgxcompute6--5</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05 00:47:47</td> </tr>
-		<tr> <td>teste-sgxcompute7-1</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05 01:00:38</td> </tr>
-		<tr> <td>teste-sgxcompute7-4</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05 01:00:43</td> </tr>
-		<tr> <td>teste-sgxcompute7-3</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05 01:00:44</td> </tr>
-		<tr> <td>teste-sgxcompute7-2</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05 01:00:46</td> </tr>
-		<tr> <td>teste-sgxcompute7-5</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05 01:00:49</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>teste-compute22-4</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 55 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-5</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 53 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-6</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 55 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-3</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 57 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-1</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 56 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-9</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 43 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-7</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 50 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-8</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 43 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-10</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 44 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-2</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 46 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-11</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 25 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-12</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 21 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-13</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 19 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-14</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 15 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-15</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 10 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-16</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 10 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-17</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 7 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-19</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 1 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-18</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 2 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-20</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 3 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-1</td> <td>maintenance</td> <td>1 Dias, 15 Horas e 11 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-2</td> <td>maintenance</td> <td>1 Dias, 15 Horas e 6 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-3</td> <td>maintenance</td> <td>1 Dias, 15 Horas e 4 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-4</td> <td>maintenance</td> <td>1 Dias, 15 Horas e 58 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-5</td> <td>maintenance</td> <td>1 Dias, 15 Horas e 56 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-6</td> <td>maintenance</td> <td>1 Dias, 15 Horas e 56 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-9</td> <td>maintenance</td> <td>1 Dias, 15 Horas e 50 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-7</td> <td>maintenance</td> <td>1 Dias, 15 Horas e 52 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-8</td> <td>maintenance</td> <td>1 Dias, 15 Horas e 53 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute22-10</td> <td>maintenance</td> <td>1 Dias, 15 Horas e 51 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute23-3</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 3 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute23-2</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 4 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute23-4</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 2 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute23-6</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 59 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute23-1</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 59 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute23-7</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 57 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute23-8</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 56 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute23-5</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 58 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute23-10</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 53 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute23-9</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 54 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute24</td> <td>maintenance</td> <td>0 Dias, 0 Horas e 33 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute24-1</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 14 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute24-2</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 12 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute24-3</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 8 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute24-5</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 4 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute24-7</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 2 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute24-4</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 2 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute24-9</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 57 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute24-8</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 2 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute24-10</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 59 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute24-6</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 58 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute25-2</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 43 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute25-3</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 34 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute25-4</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 41 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute25-1</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 40 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute25-6</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 37 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute25-7</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 26 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute25-8</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 28 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute25-9</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 26 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute25-5</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 26 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>teste-compute25-10</td> <td>maintenance</td> <td>1 Dias, 14 Horas e 23 Segundos</td> <td>2020-04-18</td> </tr>
+		<tr> <td>Billing-test</td> <td>rally.t1.medium</td> <td>2 Dias, 20 Horas e 56 Segundos</td> <td>2020-04-27</td> </tr>
+		<tr> <td>teste-2</td> <td>maintenance2</td> <td>2 Dias, 2 Horas e 1 Segundos</td> <td>2020-04-27</td> </tr>
+		<tr> <td>teste-3</td> <td>maintenance2</td> <td>2 Dias, 2 Horas e 56 Segundos</td> <td>2020-04-27</td> </tr>
+		<tr> <td>teste-1</td> <td>maintenance2</td> <td>2 Dias, 2 Horas e 0 Segundos</td> <td>2020-04-27</td> </tr>
+		<tr> <td>teste-5</td> <td>maintenance2</td> <td>2 Dias, 2 Horas e 58 Segundos</td> <td>2020-04-27</td> </tr>
+		<tr> <td>teste-4</td> <td>maintenance2</td> <td>2 Dias, 2 Horas e 57 Segundos</td> <td>2020-04-27</td> </tr>
+		<tr> <td>teste-10</td> <td>maintenance2</td> <td>2 Dias, 2 Horas e 42 Segundos</td> <td>2020-04-27</td> </tr>
+		<tr> <td>teste-7</td> <td>maintenance2</td> <td>2 Dias, 2 Horas e 49 Segundos</td> <td>2020-04-27</td> </tr>
+		<tr> <td>teste-6</td> <td>maintenance2</td> <td>2 Dias, 2 Horas e 47 Segundos</td> <td>2020-04-27</td> </tr>
+		<tr> <td>teste-8</td> <td>maintenance2</td> <td>2 Dias, 2 Horas e 42 Segundos</td> <td>2020-04-27</td> </tr>
+		<tr> <td>teste-9</td> <td>maintenance2</td> <td>2 Dias, 2 Horas e 48 Segundos</td> <td>2020-04-27</td> </tr>
+		<tr> <td>Billing-test-2</td> <td>rally.t1.medium</td> <td>0 Dias, 23 Horas e 35 Segundos</td> <td>2020-04-30</td> </tr>
+		<tr> <td>teste-compute-sgx-2</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04</td> </tr>
+		<tr> <td>teste-compute-sgx-3</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04</td> </tr>
+		<tr> <td>teste-compute-sgx-1</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04</td> </tr>
+		<tr> <td>teste-compute-sgx-4</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04</td> </tr>
+		<tr> <td>teste-compute-sgx-6</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04</td> </tr>
+		<tr> <td>teste-compute-sgx-5</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04</td> </tr>
+		<tr> <td>teste-compute-sgx-7</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04</td> </tr>
+		<tr> <td>teste-compute-sgx-9</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04</td> </tr>
+		<tr> <td>teste-compute-sgx-8</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04</td> </tr>
+		<tr> <td>teste-compute-sgx-10</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04</td> </tr>
+		<tr> <td>teste-compute5-sgx-1</td> <td>teste-sgx.epc8.tiny</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04</td> </tr>
+		<tr> <td>test-c5-compute5-sgx-1</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04</td> </tr>
+		<tr> <td>tes-c5sgxcompute5-1</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04</td> </tr>
+		<tr> <td>teste-sgxcompute6--1</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05</td> </tr>
+		<tr> <td>teste-sgxcompute6--4</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05</td> </tr>
+		<tr> <td>teste-sgxcompute6--3</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05</td> </tr>
+		<tr> <td>teste-sgxcompute6--2</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05</td> </tr>
+		<tr> <td>teste-sgxcompute6--5</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05</td> </tr>
+		<tr> <td>teste-sgxcompute7-1</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05</td> </tr>
+		<tr> <td>teste-sgxcompute7-4</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05</td> </tr>
+		<tr> <td>teste-sgxcompute7-3</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05</td> </tr>
+		<tr> <td>teste-sgxcompute7-2</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05</td> </tr>
+		<tr> <td>teste-sgxcompute7-5</td> <td>maintenance-sgx</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-05</td> </tr>
 
     </table>
     
@@ -190,7 +190,7 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
 
     </table>
     
@@ -217,7 +217,7 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
 
     </table>
     
@@ -250,38 +250,38 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>teste-upgrade</td> <td>ops.s1.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-23 12:07:29</td> </tr>
-		<tr> <td>kube-master</td> <td>ops.s1.medium</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-03 19:47:48</td> </tr>
-		<tr> <td>kube-node-2</td> <td>ops.s1.medium</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-03 19:48:36</td> </tr>
-		<tr> <td>kube-node-3</td> <td>ops.s1.medium</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-03 19:48:38</td> </tr>
-		<tr> <td>kube-node-1</td> <td>ops.s1.medium</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-03 19:48:41</td> </tr>
-		<tr> <td>srvdhcp</td> <td>ops.s1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-03 20:05:52</td> </tr>
-		<tr> <td>teste-latin</td> <td>ops.s1.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-11 12:51:26</td> </tr>
-		<tr> <td>ceph-mon-1</td> <td>lsd.t1.medium</td> <td>1 Dias, 1 Horas e 38 Segundos</td> <td>2020-04-01 19:06:14</td> </tr>
-		<tr> <td>ceph-mon-3</td> <td>lsd.t1.medium</td> <td>1 Dias, 1 Horas e 33 Segundos</td> <td>2020-04-01 19:06:18</td> </tr>
-		<tr> <td>ceph-mon-2</td> <td>lsd.t1.medium</td> <td>1 Dias, 1 Horas e 32 Segundos</td> <td>2020-04-01 19:06:20</td> </tr>
-		<tr> <td>ceph-storage-3</td> <td>lsd.t1.small</td> <td>1 Dias, 1 Horas e 58 Segundos</td> <td>2020-04-01 19:10:51</td> </tr>
-		<tr> <td>ceph-storage-1</td> <td>lsd.t1.small</td> <td>1 Dias, 1 Horas e 58 Segundos</td> <td>2020-04-01 19:10:52</td> </tr>
-		<tr> <td>ceph-storage-2</td> <td>lsd.t1.small</td> <td>1 Dias, 1 Horas e 56 Segundos</td> <td>2020-04-01 19:10:55</td> </tr>
-		<tr> <td>ceph-storage-1</td> <td>ops.s1.small</td> <td>0 Dias, 0 Horas e 49 Segundos</td> <td>2020-04-02 20:46:16</td> </tr>
-		<tr> <td>ceph-storage-3</td> <td>ops.s1.small</td> <td>0 Dias, 0 Horas e 47 Segundos</td> <td>2020-04-02 20:46:17</td> </tr>
-		<tr> <td>ceph-storage-2</td> <td>ops.s1.small</td> <td>0 Dias, 0 Horas e 45 Segundos</td> <td>2020-04-02 20:46:19</td> </tr>
-		<tr> <td>ceph-mon-2</td> <td>ops.s1.medium</td> <td>0 Dias, 0 Horas e 57 Segundos</td> <td>2020-04-02 20:47:06</td> </tr>
-		<tr> <td>ceph-mon-1</td> <td>ops.s1.medium</td> <td>0 Dias, 0 Horas e 55 Segundos</td> <td>2020-04-02 20:47:08</td> </tr>
-		<tr> <td>ceph-mon-3</td> <td>ops.s1.medium</td> <td>0 Dias, 0 Horas e 52 Segundos</td> <td>2020-04-02 20:47:11</td> </tr>
-		<tr> <td>ceph-mon-1</td> <td>ops.s1.medium</td> <td>12 Dias, 17 Horas e 1 Segundos</td> <td>2020-04-02 21:16:14</td> </tr>
-		<tr> <td>ceph-mon-2</td> <td>ops.s1.medium</td> <td>12 Dias, 17 Horas e 55 Segundos</td> <td>2020-04-02 21:16:17</td> </tr>
-		<tr> <td>ceph-mon-3</td> <td>ops.s1.medium</td> <td>12 Dias, 17 Horas e 49 Segundos</td> <td>2020-04-02 21:16:20</td> </tr>
-		<tr> <td>ceph-storage-1</td> <td>ops.s1.small</td> <td>12 Dias, 17 Horas e 38 Segundos</td> <td>2020-04-02 21:32:38</td> </tr>
-		<tr> <td>ceph-storage-3</td> <td>ops.s1.small</td> <td>12 Dias, 17 Horas e 35 Segundos</td> <td>2020-04-02 21:32:41</td> </tr>
-		<tr> <td>ceph-storage-2</td> <td>ops.s1.small</td> <td>12 Dias, 17 Horas e 33 Segundos</td> <td>2020-04-02 21:32:42</td> </tr>
-		<tr> <td>new-mon-3</td> <td>ops.s1.small</td> <td>6 Dias, 20 Horas e 39 Segundos</td> <td>2020-04-08 18:14:28</td> </tr>
-		<tr> <td>new-mon-1</td> <td>ops.s1.small</td> <td>6 Dias, 20 Horas e 34 Segundos</td> <td>2020-04-08 18:14:30</td> </tr>
-		<tr> <td>new-mon-2</td> <td>ops.s1.small</td> <td>6 Dias, 20 Horas e 33 Segundos</td> <td>2020-04-08 18:14:32</td> </tr>
-		<tr> <td>teste-after-migra</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 58 Segundos</td> <td>2020-04-15 14:48:39</td> </tr>
-		<tr> <td>teste-netdata</td> <td>ops.s1.tiny</td> <td>9 Dias, 9 Horas e 45 Segundos</td> <td>2020-04-21 14:48:15</td> </tr>
-		<tr> <td>mattermost-upgrade</td> <td>ops.s1.large</td> <td>0 Dias, 0 Horas e 35 Segundos</td> <td>2020-04-28 18:22:01</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>teste-upgrade</td> <td>ops.s1.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-23</td> </tr>
+		<tr> <td>kube-master</td> <td>ops.s1.medium</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-03</td> </tr>
+		<tr> <td>kube-node-2</td> <td>ops.s1.medium</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-03</td> </tr>
+		<tr> <td>kube-node-3</td> <td>ops.s1.medium</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-03</td> </tr>
+		<tr> <td>kube-node-1</td> <td>ops.s1.medium</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-03</td> </tr>
+		<tr> <td>srvdhcp</td> <td>ops.s1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-03</td> </tr>
+		<tr> <td>teste-latin</td> <td>ops.s1.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-11</td> </tr>
+		<tr> <td>ceph-mon-1</td> <td>lsd.t1.medium</td> <td>1 Dias, 1 Horas e 38 Segundos</td> <td>2020-04-01</td> </tr>
+		<tr> <td>ceph-mon-3</td> <td>lsd.t1.medium</td> <td>1 Dias, 1 Horas e 33 Segundos</td> <td>2020-04-01</td> </tr>
+		<tr> <td>ceph-mon-2</td> <td>lsd.t1.medium</td> <td>1 Dias, 1 Horas e 32 Segundos</td> <td>2020-04-01</td> </tr>
+		<tr> <td>ceph-storage-3</td> <td>lsd.t1.small</td> <td>1 Dias, 1 Horas e 58 Segundos</td> <td>2020-04-01</td> </tr>
+		<tr> <td>ceph-storage-1</td> <td>lsd.t1.small</td> <td>1 Dias, 1 Horas e 58 Segundos</td> <td>2020-04-01</td> </tr>
+		<tr> <td>ceph-storage-2</td> <td>lsd.t1.small</td> <td>1 Dias, 1 Horas e 56 Segundos</td> <td>2020-04-01</td> </tr>
+		<tr> <td>ceph-storage-1</td> <td>ops.s1.small</td> <td>0 Dias, 0 Horas e 49 Segundos</td> <td>2020-04-02</td> </tr>
+		<tr> <td>ceph-storage-3</td> <td>ops.s1.small</td> <td>0 Dias, 0 Horas e 47 Segundos</td> <td>2020-04-02</td> </tr>
+		<tr> <td>ceph-storage-2</td> <td>ops.s1.small</td> <td>0 Dias, 0 Horas e 45 Segundos</td> <td>2020-04-02</td> </tr>
+		<tr> <td>ceph-mon-2</td> <td>ops.s1.medium</td> <td>0 Dias, 0 Horas e 57 Segundos</td> <td>2020-04-02</td> </tr>
+		<tr> <td>ceph-mon-1</td> <td>ops.s1.medium</td> <td>0 Dias, 0 Horas e 55 Segundos</td> <td>2020-04-02</td> </tr>
+		<tr> <td>ceph-mon-3</td> <td>ops.s1.medium</td> <td>0 Dias, 0 Horas e 52 Segundos</td> <td>2020-04-02</td> </tr>
+		<tr> <td>ceph-mon-1</td> <td>ops.s1.medium</td> <td>12 Dias, 17 Horas e 1 Segundos</td> <td>2020-04-02</td> </tr>
+		<tr> <td>ceph-mon-2</td> <td>ops.s1.medium</td> <td>12 Dias, 17 Horas e 55 Segundos</td> <td>2020-04-02</td> </tr>
+		<tr> <td>ceph-mon-3</td> <td>ops.s1.medium</td> <td>12 Dias, 17 Horas e 49 Segundos</td> <td>2020-04-02</td> </tr>
+		<tr> <td>ceph-storage-1</td> <td>ops.s1.small</td> <td>12 Dias, 17 Horas e 38 Segundos</td> <td>2020-04-02</td> </tr>
+		<tr> <td>ceph-storage-3</td> <td>ops.s1.small</td> <td>12 Dias, 17 Horas e 35 Segundos</td> <td>2020-04-02</td> </tr>
+		<tr> <td>ceph-storage-2</td> <td>ops.s1.small</td> <td>12 Dias, 17 Horas e 33 Segundos</td> <td>2020-04-02</td> </tr>
+		<tr> <td>new-mon-3</td> <td>ops.s1.small</td> <td>6 Dias, 20 Horas e 39 Segundos</td> <td>2020-04-08</td> </tr>
+		<tr> <td>new-mon-1</td> <td>ops.s1.small</td> <td>6 Dias, 20 Horas e 34 Segundos</td> <td>2020-04-08</td> </tr>
+		<tr> <td>new-mon-2</td> <td>ops.s1.small</td> <td>6 Dias, 20 Horas e 33 Segundos</td> <td>2020-04-08</td> </tr>
+		<tr> <td>teste-after-migra</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 58 Segundos</td> <td>2020-04-15</td> </tr>
+		<tr> <td>teste-netdata</td> <td>ops.s1.tiny</td> <td>9 Dias, 9 Horas e 45 Segundos</td> <td>2020-04-21</td> </tr>
+		<tr> <td>mattermost-upgrade</td> <td>ops.s1.large</td> <td>0 Dias, 0 Horas e 35 Segundos</td> <td>2020-04-28</td> </tr>
 
     </table>
     
@@ -321,27 +321,27 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>paste-lsd</td> <td>ops.s1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-07-02 12:51:05</td> </tr>
-		<tr> <td>windows8.1-Andrey</td> <td>ops.s1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-07-15 19:54:50</td> </tr>
-		<tr> <td>etherpad</td> <td>ops.s1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-07-22 19:59:37</td> </tr>
-		<tr> <td>mattermost</td> <td>ops.s1.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-07-22 20:45:59</td> </tr>
-		<tr> <td>racktables</td> <td>ops.s1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-07-29 20:50:34</td> </tr>
-		<tr> <td>gitlab</td> <td>ops.s1.gitlab</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-03 15:27:03</td> </tr>
-		<tr> <td>wiki-suporte</td> <td>ops.s1.wiki</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-03 15:31:24</td> </tr>
-		<tr> <td>owncloud</td> <td>ops.s1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-03 16:24:44</td> </tr>
-		<tr> <td>web-srv-sites</td> <td>ops.s1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-07 11:37:45</td> </tr>
-		<tr> <td>unifi-controller</td> <td>ops.s1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-07 13:52:20</td> </tr>
-		<tr> <td>oneview3-prod</td> <td>ops.s1.oneview3-prod</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-08 13:03:54</td> </tr>
-		<tr> <td>web-srv-04</td> <td>ops.s1.wiki</td> <td>16 Dias, 0 Horas e 23 Segundos</td> <td>2019-08-08 13:26:10</td> </tr>
-		<tr> <td>otrs-srv</td> <td>ops.s1.wiki</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-08 19:41:02</td> </tr>
-		<tr> <td>web-srv-02</td> <td>ops.s1.wiki</td> <td>16 Dias, 0 Horas e 27 Segundos</td> <td>2019-08-09 17:00:59</td> </tr>
-		<tr> <td>srv-giga-rebuild-01</td> <td>ops.s1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-10-21 17:46:14</td> </tr>
-		<tr> <td>vault</td> <td>ops.s1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-09 17:46:07</td> </tr>
-		<tr> <td>test-gitlab</td> <td>ops.s1.gitlab</td> <td>0 Dias, 2 Horas e 17 Segundos</td> <td>2020-04-06 18:09:19</td> </tr>
-		<tr> <td>otrs-srv-prod</td> <td>ops.s1.wiki</td> <td>13 Dias, 4 Horas e 47 Segundos</td> <td>2020-04-17 19:06:13</td> </tr>
-		<tr> <td>test-gitlab</td> <td>ops.s1.gitlab</td> <td>0 Dias, 1 Horas e 41 Segundos</td> <td>2020-04-28 13:48:14</td> </tr>
-		<tr> <td>test-gitlab</td> <td>ops.s1.gitlab</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04 17:12:49</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>paste-lsd</td> <td>ops.s1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-07-02</td> </tr>
+		<tr> <td>windows8.1-Andrey</td> <td>ops.s1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-07-15</td> </tr>
+		<tr> <td>etherpad</td> <td>ops.s1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-07-22</td> </tr>
+		<tr> <td>mattermost</td> <td>ops.s1.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-07-22</td> </tr>
+		<tr> <td>racktables</td> <td>ops.s1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-07-29</td> </tr>
+		<tr> <td>gitlab</td> <td>ops.s1.gitlab</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-03</td> </tr>
+		<tr> <td>wiki-suporte</td> <td>ops.s1.wiki</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-03</td> </tr>
+		<tr> <td>owncloud</td> <td>ops.s1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-03</td> </tr>
+		<tr> <td>web-srv-sites</td> <td>ops.s1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-07</td> </tr>
+		<tr> <td>unifi-controller</td> <td>ops.s1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-07</td> </tr>
+		<tr> <td>oneview3-prod</td> <td>ops.s1.oneview3-prod</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-08</td> </tr>
+		<tr> <td>web-srv-04</td> <td>ops.s1.wiki</td> <td>16 Dias, 0 Horas e 23 Segundos</td> <td>2019-08-08</td> </tr>
+		<tr> <td>otrs-srv</td> <td>ops.s1.wiki</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2019-08-08</td> </tr>
+		<tr> <td>web-srv-02</td> <td>ops.s1.wiki</td> <td>16 Dias, 0 Horas e 27 Segundos</td> <td>2019-08-09</td> </tr>
+		<tr> <td>srv-giga-rebuild-01</td> <td>ops.s1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-10-21</td> </tr>
+		<tr> <td>vault</td> <td>ops.s1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-09</td> </tr>
+		<tr> <td>test-gitlab</td> <td>ops.s1.gitlab</td> <td>0 Dias, 2 Horas e 17 Segundos</td> <td>2020-04-06</td> </tr>
+		<tr> <td>otrs-srv-prod</td> <td>ops.s1.wiki</td> <td>13 Dias, 4 Horas e 47 Segundos</td> <td>2020-04-17</td> </tr>
+		<tr> <td>test-gitlab</td> <td>ops.s1.gitlab</td> <td>0 Dias, 1 Horas e 41 Segundos</td> <td>2020-04-28</td> </tr>
+		<tr> <td>test-gitlab</td> <td>ops.s1.gitlab</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-05-04</td> </tr>
 
     </table>
     

--- a/reports/04-2020/joao.arthur@computacao.ufcg.edu.br.html
+++ b/reports/04-2020/joao.arthur@computacao.ufcg.edu.br.html
@@ -32,9 +32,9 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>teste</td> <td>lsd.t1.small</td> <td>1 Dias, 21 Horas e 40 Segundos</td> <td>2020-04-11 08:20:17</td> </tr>
-		<tr> <td>epol-backup</td> <td>lsd.t1.medium</td> <td>17 Dias, 18 Horas e 51 Segundos</td> <td>2020-04-13 05:52:03</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>teste</td> <td>lsd.t1.small</td> <td>1 Dias, 21 Horas e 40 Segundos</td> <td>2020-04-11</td> </tr>
+		<tr> <td>epol-backup</td> <td>lsd.t1.medium</td> <td>17 Dias, 18 Horas e 51 Segundos</td> <td>2020-04-13</td> </tr>
 
     </table>
     

--- a/reports/04-2020/joseana@computacao.ufcg.edu.br.html
+++ b/reports/04-2020/joseana@computacao.ufcg.edu.br.html
@@ -31,10 +31,10 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>praca</td> <td>lsd.t1.tiny_praca</td> <td>10 Dias, 1 Horas e 39 Segundos</td> <td>2020-04-06 23:00:05</td> </tr>
-		<tr> <td>praca</td> <td>lsd.t1.tiny_praca</td> <td>3 Dias, 20 Horas e 24 Segundos</td> <td>2020-04-17 00:36:33</td> </tr>
-		<tr> <td>praca</td> <td>lsd.t1.tiny_praca</td> <td>10 Dias, 1 Horas e 5 Segundos</td> <td>2020-04-20 22:35:55</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>praca</td> <td>lsd.t1.tiny_praca</td> <td>10 Dias, 1 Horas e 39 Segundos</td> <td>2020-04-06</td> </tr>
+		<tr> <td>praca</td> <td>lsd.t1.tiny_praca</td> <td>3 Dias, 20 Horas e 24 Segundos</td> <td>2020-04-17</td> </tr>
+		<tr> <td>praca</td> <td>lsd.t1.tiny_praca</td> <td>10 Dias, 1 Horas e 5 Segundos</td> <td>2020-04-20</td> </tr>
 
     </table>
     

--- a/reports/04-2020/lbmarinho@computacao.ufcg.edu.br.html
+++ b/reports/04-2020/lbmarinho@computacao.ufcg.edu.br.html
@@ -31,8 +31,8 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>quebra-quebra</td> <td>lsd.t1.medium</td> <td>16 Dias, 3 Horas e 23 Segundos</td> <td>2020-04-14 20:18:37</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>quebra-quebra</td> <td>lsd.t1.medium</td> <td>16 Dias, 3 Horas e 23 Segundos</td> <td>2020-04-14</td> </tr>
 
     </table>
     
@@ -60,7 +60,7 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
 
     </table>
     
@@ -87,11 +87,11 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>test-scp</td> <td>lsd.t1.nano</td> <td>3 Dias, 13 Horas e 26 Segundos</td> <td>2020-04-03 05:56:03</td> </tr>
-		<tr> <td>test-scp</td> <td>lsd.t1.nano</td> <td>24 Dias, 4 Horas e 11 Segundos</td> <td>2020-04-06 19:49:49</td> </tr>
-		<tr> <td>dca-webjobs</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 22 Segundos</td> <td>2020-04-06 22:09:06</td> </tr>
-		<tr> <td>dca-ci</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 28 Segundos</td> <td>2020-04-06 22:32:54</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>test-scp</td> <td>lsd.t1.nano</td> <td>3 Dias, 13 Horas e 26 Segundos</td> <td>2020-04-03</td> </tr>
+		<tr> <td>test-scp</td> <td>lsd.t1.nano</td> <td>24 Dias, 4 Horas e 11 Segundos</td> <td>2020-04-06</td> </tr>
+		<tr> <td>dca-webjobs</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 22 Segundos</td> <td>2020-04-06</td> </tr>
+		<tr> <td>dca-ci</td> <td>lsd.t1.nano</td> <td>0 Dias, 0 Horas e 28 Segundos</td> <td>2020-04-06</td> </tr>
 
     </table>
     

--- a/reports/04-2020/nazareno@computacao.ufcg.edu.br.html
+++ b/reports/04-2020/nazareno@computacao.ufcg.edu.br.html
@@ -31,10 +31,10 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>leggo-dados</td> <td>lsd.t1.medium</td> <td>17 Dias, 7 Horas e 51 Segundos</td> <td>2020-04-13 16:22:09</td> </tr>
-		<tr> <td>perfil-parlamentar-dados</td> <td>lsd.t1.medium</td> <td>17 Dias, 5 Horas e 17 Segundos</td> <td>2020-04-13 18:49:43</td> </tr>
-		<tr> <td>leggo-runner</td> <td>lsd.t1.medium</td> <td>16 Dias, 11 Horas e 9 Segundos</td> <td>2020-04-14 12:34:51</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>leggo-dados</td> <td>lsd.t1.medium</td> <td>17 Dias, 7 Horas e 51 Segundos</td> <td>2020-04-13</td> </tr>
+		<tr> <td>perfil-parlamentar-dados</td> <td>lsd.t1.medium</td> <td>17 Dias, 5 Horas e 17 Segundos</td> <td>2020-04-13</td> </tr>
+		<tr> <td>leggo-runner</td> <td>lsd.t1.medium</td> <td>16 Dias, 11 Horas e 9 Segundos</td> <td>2020-04-14</td> </tr>
 
     </table>
     
@@ -62,7 +62,7 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
 
     </table>
     
@@ -89,7 +89,7 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
 
     </table>
     
@@ -116,7 +116,7 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
 
     </table>
     
@@ -143,7 +143,7 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
 
     </table>
     
@@ -170,11 +170,11 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>opencpu-cursos-ufcg</td> <td>lsd.t2.large</td> <td>20 Dias, 2 Horas e 18 Segundos</td> <td>2020-04-10 21:07:42</td> </tr>
-		<tr> <td>mysql-cursos-ufcg</td> <td>lsd.t1.medium</td> <td>20 Dias, 2 Horas e 58 Segundos</td> <td>2020-04-10 21:16:02</td> </tr>
-		<tr> <td>analytics-server</td> <td>lsd.t2.large</td> <td>0 Dias, 4 Horas e 39 Segundos</td> <td>2020-04-10 22:04:45</td> </tr>
-		<tr> <td>analytics-server</td> <td>lsd.t2.large</td> <td>19 Dias, 21 Horas e 19 Segundos</td> <td>2020-04-11 02:15:41</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>opencpu-cursos-ufcg</td> <td>lsd.t2.large</td> <td>20 Dias, 2 Horas e 18 Segundos</td> <td>2020-04-10</td> </tr>
+		<tr> <td>mysql-cursos-ufcg</td> <td>lsd.t1.medium</td> <td>20 Dias, 2 Horas e 58 Segundos</td> <td>2020-04-10</td> </tr>
+		<tr> <td>analytics-server</td> <td>lsd.t2.large</td> <td>0 Dias, 4 Horas e 39 Segundos</td> <td>2020-04-10</td> </tr>
+		<tr> <td>analytics-server</td> <td>lsd.t2.large</td> <td>19 Dias, 21 Horas e 19 Segundos</td> <td>2020-04-11</td> </tr>
 
     </table>
     
@@ -206,8 +206,8 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>analyticsmp2</td> <td>lsd.t2.xlarge</td> <td>20 Dias, 7 Horas e 56 Segundos</td> <td>2020-04-10 16:47:04</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>analyticsmp2</td> <td>lsd.t2.xlarge</td> <td>20 Dias, 7 Horas e 56 Segundos</td> <td>2020-04-10</td> </tr>
 
     </table>
     
@@ -235,7 +235,7 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
 
     </table>
     
@@ -262,8 +262,8 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>contribua</td> <td>lsd.t1.small</td> <td>17 Dias, 4 Horas e 3 Segundos</td> <td>2020-04-13 19:43:57</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>contribua</td> <td>lsd.t1.small</td> <td>17 Dias, 4 Horas e 3 Segundos</td> <td>2020-04-13</td> </tr>
 
     </table>
     

--- a/reports/04-2020/raquel@computacao.ufcg.edu.br.html
+++ b/reports/04-2020/raquel@computacao.ufcg.edu.br.html
@@ -31,10 +31,10 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>master</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-18 17:42:25</td> </tr>
-		<tr> <td>slave-1</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-18 17:53:43</td> </tr>
-		<tr> <td>slave-2</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-18 19:37:24</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>master</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-18</td> </tr>
+		<tr> <td>slave-1</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-18</td> </tr>
+		<tr> <td>slave-2</td> <td>lsd.t1.medium</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-03-18</td> </tr>
 
     </table>
     
@@ -62,17 +62,17 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>dfq-run-2</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-29 19:44:28</td> </tr>
-		<tr> <td>dfq-run-4</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-29 19:44:29</td> </tr>
-		<tr> <td>dfq-run-3</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-29 19:44:33</td> </tr>
-		<tr> <td>dfq-run-1</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-29 19:44:35</td> </tr>
-		<tr> <td>dfq-work</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-30 14:43:50</td> </tr>
-		<tr> <td>dfq-run-5</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-03 14:47:52</td> </tr>
-		<tr> <td>dfq-run-6</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-03 14:48:37</td> </tr>
-		<tr> <td>dfq-run-7</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-03 14:50:06</td> </tr>
-		<tr> <td>dfq-run-8</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-03 14:51:21</td> </tr>
-		<tr> <td>dfq-work2</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-03 14:52:46</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>dfq-run-2</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-29</td> </tr>
+		<tr> <td>dfq-run-4</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-29</td> </tr>
+		<tr> <td>dfq-run-3</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-29</td> </tr>
+		<tr> <td>dfq-run-1</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-29</td> </tr>
+		<tr> <td>dfq-work</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-01-30</td> </tr>
+		<tr> <td>dfq-run-5</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-03</td> </tr>
+		<tr> <td>dfq-run-6</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-03</td> </tr>
+		<tr> <td>dfq-run-7</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-03</td> </tr>
+		<tr> <td>dfq-run-8</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-03</td> </tr>
+		<tr> <td>dfq-work2</td> <td>lsd.t2.large</td> <td>0 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-03</td> </tr>
 
     </table>
     

--- a/reports/04-2020/reinaldo@computacao.ufcg.edu.br.html
+++ b/reports/04-2020/reinaldo@computacao.ufcg.edu.br.html
@@ -31,11 +31,11 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>perf1</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-12-10 17:52:58</td> </tr>
-		<tr> <td>perf2</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-12-10 18:00:29</td> </tr>
-		<tr> <td>perf3</td> <td>lsd.t1.tiny</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-12-11 15:10:48</td> </tr>
-		<tr> <td>Teste_EVE</td> <td>lsd.t2.large</td> <td>21 Dias, 6 Horas e 51 Segundos</td> <td>2020-04-09 17:43:09</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>perf1</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-12-10</td> </tr>
+		<tr> <td>perf2</td> <td>lsd.t1.nano</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-12-10</td> </tr>
+		<tr> <td>perf3</td> <td>lsd.t1.tiny</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-12-11</td> </tr>
+		<tr> <td>Teste_EVE</td> <td>lsd.t2.large</td> <td>21 Dias, 6 Horas e 51 Segundos</td> <td>2020-04-09</td> </tr>
 
     </table>
     

--- a/reports/04-2020/temmanuel@computacao.ufcg.edu.br.html
+++ b/reports/04-2020/temmanuel@computacao.ufcg.edu.br.html
@@ -31,8 +31,8 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>lesandrop</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-07-24 17:04:45</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>lesandrop</td> <td>lsd.t2.large</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-07-24</td> </tr>
 
     </table>
     
@@ -60,8 +60,8 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>queenbee</td> <td>lsd.t1.tiny</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-21 13:18:11</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>queenbee</td> <td>lsd.t1.tiny</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-21</td> </tr>
 
     </table>
     
@@ -90,8 +90,8 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>gateway</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-23 23:31:31</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>gateway</td> <td>lsd.t1.small</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2019-11-23</td> </tr>
 
     </table>
     

--- a/reports/04-2020/wilkerson@computacao.ufcg.edu.br.html
+++ b/reports/04-2020/wilkerson@computacao.ufcg.edu.br.html
@@ -32,9 +32,9 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>prog1</td> <td>lsd.t1.medium</td> <td>28 Dias, 0 Horas e 19 Segundos</td> <td>2020-04-02 23:11:41</td> </tr>
-		<tr> <td>estudantes</td> <td>lsd.t1.medium</td> <td>2 Dias, 6 Horas e 36 Segundos</td> <td>2020-04-28 17:51:24</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>prog1</td> <td>lsd.t1.medium</td> <td>28 Dias, 0 Horas e 19 Segundos</td> <td>2020-04-02</td> </tr>
+		<tr> <td>estudantes</td> <td>lsd.t1.medium</td> <td>2 Dias, 6 Horas e 36 Segundos</td> <td>2020-04-28</td> </tr>
 
     </table>
     
@@ -63,8 +63,8 @@
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
-		<tr> <td>IngenicoServer</td> <td>lsd.t2.xlarge</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-12 11:04:23</td> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
+		<tr> <td>IngenicoServer</td> <td>lsd.t2.xlarge</td> <td>30 Dias, 0 Horas e 0 Segundos</td> <td>2020-02-12</td> </tr>
 
     </table>
     

--- a/templates/body_template.txt
+++ b/templates/body_template.txt
@@ -14,7 +14,7 @@ $vol$
     </div>
 
     <table>
-        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data</th> </tr>
+        <tr>  <th>Nome</th> <th>Flavor</th> <th>Tempo de uso</th> <th>Data de criação</th> </tr>
 $inst$
     </table>
     


### PR DESCRIPTION
Temos agora uma nova coluna nos reports, que é: Data de criação(ano-mês-dia hora:minuto:segundo), a ordem em que as instâncias são exibidas agora está associada a data em que foi criada e as intâncias com erros de iniciação não aparecerão mais nos reports.
close #10 